### PR TITLE
fix: close sessions reliably and report the build version

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -203,7 +203,7 @@ pub fn info(cfg: &Config, stats: &Stats, started: u64) -> Vec<u8> {
          cache_hits:{}\r\ncache_misses:{}\r\ncache_invalidations:{}\r\n\
          cache_armed_workers:{}\r\n\
          worker_commands:{}\r\n",
-        env!("CARGO_PKG_VERSION"),
+        crate::VERSION,
         std::process::id(),
         cfg.port,
         now.saturating_sub(started),
@@ -393,6 +393,7 @@ mod tests {
                 .map(|v| v.trim_end().to_string())
         };
         assert_eq!(field("connected_clients").as_deref(), Some("7"));
+        assert_eq!(field("mithril_version").as_deref(), Some(crate::VERSION));
         assert_eq!(
             field("worker_threads").as_deref(),
             Some(cfg.workers.to_string().as_str())

--- a/src/client.rs
+++ b/src/client.rs
@@ -2775,7 +2775,7 @@ async fn pubsub_relay(
 
 fn mark_closed(link: &WriterLink) {
     link.closed.set(true);
-    link.closed_notify.notify_waiters();
+    link.closed_notify.notify_one();
 }
 
 // a push holds one window slot from here until the writer emits it
@@ -3123,6 +3123,16 @@ mod tests {
 
     fn spec(name: &str) -> &'static Spec {
         command::lookup(name.as_bytes()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn close_notification_survives_a_late_reader() {
+        let link = WriterLink::default();
+        mark_closed(&link);
+        tokio::time::timeout(Duration::from_millis(10), link.closed_notify.notified())
+            .await
+            .unwrap();
+        assert!(link.closed.get());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,14 @@
 //! Mithril: a Redis Cluster proxy.
 
+pub const VERSION: &str = match option_env!("MITHRIL_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};
+pub const REVISION: &str = match option_env!("MITHRIL_REVISION") {
+    Some(v) => v,
+    None => "unknown",
+};
+
 pub mod config;
 pub mod server;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,14 +3,6 @@
 use mithril::config::Config;
 
 const USAGE: &str = "usage: mithril <conf-file> [--<key> <value>]...";
-const VERSION: &str = match option_env!("MITHRIL_VERSION") {
-    Some(v) => v,
-    None => env!("CARGO_PKG_VERSION"),
-};
-const REVISION: &str = match option_env!("MITHRIL_REVISION") {
-    Some(v) => v,
-    None => "unknown",
-};
 
 fn main() {
     let mut args = std::env::args().skip(1);
@@ -19,7 +11,7 @@ fn main() {
     while let Some(arg) = args.next() {
         match arg.as_str() {
             "--version" => {
-                println!("mithril {VERSION} ({REVISION})");
+                println!("mithril {} ({})", mithril::VERSION, mithril::REVISION);
                 return;
             }
             "--help" => {


### PR DESCRIPTION
## Summary

- store the terminal session notification so a relay close that lands while dispatch is awaiting cannot strand the reader or its maxclients slot
- share the injected build version between the CLI and INFO output
- cover a close that precedes reader registration and assert INFO uses the shared version

## Verification

- reviewed every closed notification producer and waiter
- reviewed all touched Rust files and the final diff
- git diff --check
- lint, unit tests, and compilation were not run locally; GitHub Actions will run the project gates