### PR TITLE
Ride out atomic slot migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ thread-per-core runtime and zero-copy frame forwarding.
   pipelining is preserved end to end
 - **Full cluster absorption** — slot routing with per-slot multi-key fan-out,
   transparent MOVED/ASK retry, multi-key commands that ride out a migrating
-  slot (a `TRYAGAIN` part is re-issued key by key), all verified against
-  live slot migrations, and single-virtual-node cluster emulation so
+  slot (a `TRYAGAIN` part is re-issued key by key), atomic slot migrations
+  ridden out through their handoff, all verified against live migrations, and
+  single-virtual-node cluster emulation so
   cluster-aware clients work unchanged against one endpoint
 - **Reply cache** — optional worker-local GET/MGET cache kept coherent by the
   cluster itself: every backend connection redirects RESP3 key tracking to
@@ -79,9 +80,9 @@ See [`mithril.conf.sample`](mithril.conf.sample) and the
 make test lint fmt-check   # the CI gate
 ```
 
-The integration suite lives in [`it/`](it/): 87 dockerized tests driving a
+The integration suite lives in [`it/`](it/): 88 dockerized tests driving a
 real 3-master/3-replica cluster through the proxy with redis-py — including
-a live slot migration under multi-key commands — run against redis 6.2
+live slot migrations (legacy and atomic) under traffic — run against redis 6.2
 through 8.10 and valkey 9.1 in every mode combination (`backend-sharding`,
 `reply-cache`).
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -29,6 +29,14 @@
 - Blocking commands and pubsub use dedicated backend connections.
 - MOVED/ASK are absorbed: one transparent retry against the named target,
   plus a debounced topology refresh.
+- An atomic slot migration (Valkey 9 `CLUSTER MIGRATESLOTS`, Redis 8.4
+  `CLUSTER MIGRATION`) hands the slot over while its two nodes briefly
+  disagree on the owner, so a request can be redirected back and forth: a
+  single-slot request redirected a second time follows up to six further
+  redirects with a wait before each (2 ms, doubling) instead of failing,
+  and the client sees only its reply. A pipelined client with later
+  requests already in flight receives `TRYAGAIN` for it instead, as with
+  the multi-key case below.
 - A multi-key command whose keys are split across a migrating slot
   (`TRYAGAIN` from the server) is re-issued key by key, so it completes
   through the migration; a same-slot MSET/DEL is then no longer atomic, and

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -123,7 +123,9 @@ misbehaves:
 - SCRIPT KILL, SCRIPT DEBUG and FUNCTION KILL
 - FLUSHDB, cluster-wide KEYS
 - server management: WAIT, DEBUG, LATENCY, MEMORY, SHUTDOWN,
-  FAILOVER, REPLICAOF, SAVE/BGSAVE, MIGRATE and similar
+  FAILOVER, REPLICAOF, SAVE/BGSAVE, MIGRATE and similar; slot migrations
+  (CLUSTER SETSLOT, CLUSTER MIGRATION, CLUSTER MIGRATESLOTS) are issued to
+  the nodes directly and the proxy rides them out
 - the search module (FT.*), whose indexes are not keys
 
 RANDOMKEY samples one random master's keyspace, not the whole cluster.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,9 +1,12 @@
 # Compatibility
 
-The 87-test integration suite runs against each backend, in every mode
+The 88-test integration suite runs against each backend, in every mode
 combination (`backend-sharding`, `reply-cache`), with full cluster
 teardown/recreate between versions; it includes a live slot migration
-(CLUSTER SETSLOT MIGRATING/IMPORTING + MIGRATE) under multi-key commands:
+(CLUSTER SETSLOT MIGRATING/IMPORTING + MIGRATE) under multi-key commands
+and, on Redis 8.4+ and Valkey 9, an atomic slot migration (`CLUSTER
+MIGRATION IMPORT` / `CLUSTER MIGRATESLOTS`) moved back and forth under a
+single-key write stream, which must see no error and lose no increment:
 
 | backend | server version | result |
 |---|---|---|

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -11,7 +11,7 @@ so placement skew is visible at a glance.
 | Server | `mithril_version`, `process_id`, `tcp_port`, `uptime_in_seconds`, `config_file` |
 | Clients | `connected_clients` |
 | CPU | `used_cpu_sys`, `used_cpu_user` |
-| Stats | `total_connections_received`, `total_commands_processed`, `total_net_input_bytes`, `total_net_output_bytes`, `total_errors`, `redirections`, session lifecycle counters (`readers_exited`, `writers_exited`, `sessions_closed`) |
+| Stats | `total_connections_received`, `total_commands_processed`, `total_net_input_bytes`, `total_net_output_bytes`, `total_errors`, `redirections`, `redirect_waits`, session lifecycle counters (`readers_exited`, `writers_exited`, `sessions_closed`) |
 | Mithril | `worker_threads`, `backend_conns_per_node`, `backend_sharding`, `slave_mode`, `reply_cache`, `cache_hits`, `cache_misses`, `cache_invalidations`, `cache_entries`, `cache_bytes`, `cache_flips`, `cache_armed_workers`, `worker_commands` (per-worker) |
 
 `CLIENT LIST` lists every connection across workers (id, addr, fd, name,
@@ -36,7 +36,11 @@ should stop routing before signaling.
 MOVED/ASK redirects are absorbed transparently (one retry against the named
 target) and each one schedules a topology refresh, so a live slot migration
 or a failover converges within the refresh debounce plus one round trip —
-verified against a live `CLUSTER SETSLOT` migration under traffic. Multi-key
+verified against a live `CLUSTER SETSLOT` migration under traffic and
+against atomic slot migrations (Redis 8.4+ `CLUSTER MIGRATION`, Valkey 9
+`CLUSTER MIGRATESLOTS`), whose handoff can redirect a request back and
+forth for a moment: such a request follows the redirects with short waits
+between them, and `INFO` counts these as `redirect_waits`. Multi-key
 commands that the server refuses mid-migration (`TRYAGAIN`, keys split
 across source and target) are re-issued key by key, so they complete too.
 If a slot has no known owner the client receives `-CLUSTERDOWN`; if a retry

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -631,6 +631,78 @@ def test_multikey_survives_a_migrating_slot(r, cluster_direct, key_prefix):
         dst.close()
 
 
+def _migrate_slot(source, target, slot, probe):
+    """Atomic slot migration of `slot` to `target`, waited until `source` redirects."""
+    if "valkey_version" in target.info("server"):
+        target_id = target.execute_command("CLUSTER MYID")
+        assert source.execute_command("CLUSTER MIGRATESLOTS", "SLOTSRANGE", slot, slot, "NODE", target_id) == "OK"
+    else:
+        target.execute_command("CLUSTER MIGRATION", "IMPORT", slot, slot)
+    for _ in range(600):
+        if _moved(source, probe):
+            return
+        time.sleep(0.05)
+    pytest.fail("slot migration did not complete")
+
+
+def _moved(node, key):
+    try:
+        node.get(key)
+    except redis.exceptions.ResponseError as e:
+        return str(e).startswith("MOVED")
+    return False
+
+
+def test_atomic_slot_migration_under_traffic(r, cluster_direct, new_conn, key_prefix):
+    _needs(cluster_direct, (8, 4))
+    counter = f"{{{key_prefix}}}:n"
+    keys = [f"{{{key_prefix}}}:{i}" for i in range(20000)]
+    slot = key_slot(counter.encode())
+    src_node = cluster_direct.get_node_from_key(counter)
+    dst_node = next(
+        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
+    )
+    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
+    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    bulk = new_conn()
+    pipe = bulk.pipeline(transaction=False)
+    for k in keys:
+        pipe.set(k, "x" * 1000)
+    pipe.execute()
+    stop, errors, last = threading.Event(), [], [0]
+
+    def churn():
+        c = new_conn()
+        while not stop.is_set() and len(errors) < 20:
+            try:
+                n = c.incr(counter)
+                if n != last[0] + 1 or c.get(keys[7]) != "x" * 1000:
+                    errors.append(f"incr {last[0]} -> {n}")
+                last[0] = n
+            except redis.exceptions.RedisError as e:
+                errors.append(repr(e))
+
+    worker = threading.Thread(target=churn)
+    worker.start()
+    try:
+        for source, target in [(src, dst), (dst, src)] * 2:
+            _migrate_slot(source, target, slot, counter)
+            assert target.execute_command("CLUSTER COUNTKEYSINSLOT", slot) >= len(keys) + 1
+        stop.set()
+        worker.join(30)
+        final = r.get(counter)
+    finally:
+        stop.set()
+        worker.join(30)
+        if _moved(src, counter):
+            _migrate_slot(dst, src, slot, counter)
+        bulk.delete(counter, *keys)
+        src.close()
+        dst.close()
+    assert errors == []
+    assert last[0] > 0 and int(final) == last[0]
+
+
 def test_cache_mget_hits_and_read_your_writes(cache_proxy, key_prefix):
     r = cache_proxy
     a, b, c = f"{{{key_prefix}}}a", f"{{{key_prefix}}}b", f"{key_prefix}:c"

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -215,7 +215,7 @@ pub fn info(cfg: &Config, stats: &Stats, started: u64) -> Vec<u8> {
          # CPU\r\nused_cpu_sys:{:.3}\r\nused_cpu_user:{:.3}\r\n\r\n\
          # Stats\r\ntotal_connections_received:{}\r\ntotal_commands_processed:{}\r\n\
          total_net_input_bytes:{}\r\ntotal_net_output_bytes:{}\r\n\
-         total_errors:{}\r\nredirections:{}\r\n\
+         total_errors:{}\r\nredirections:{}\r\nredirect_waits:{}\r\n\
          readers_exited:{}\r\nwriters_exited:{}\r\nsessions_closed:{}\r\n\r\n\
          # Mithril\r\nworker_threads:{}\r\nbackend_conns_per_node:{}\r\n\
          backend_sharding:{}\r\nslave_mode:{}\r\nreply_cache:{}\r\n\
@@ -236,6 +236,7 @@ pub fn info(cfg: &Config, stats: &Stats, started: u64) -> Vec<u8> {
         stats.sum(|w| &w.bytes_out),
         stats.sum(|w| &w.errors),
         stats.sum(|w| &w.redirects),
+        stats.sum(|w| &w.redirect_waits),
         stats.sum(|w| &w.readers_exited),
         stats.sum(|w| &w.writers_exited),
         stats.sum(|w| &w.sessions_closed),

--- a/src/client/fanout.rs
+++ b/src/client/fanout.rs
@@ -587,6 +587,17 @@ pub(super) async fn resend_singles(
     }
 }
 
+/// The slot a request runs in, by the first key of its declared range, STREAMS list or store.
+pub(super) fn request_slot(frame: &Bytes) -> Option<u16> {
+    let (argc, _) = resp::scan_int_line(frame, 1)?;
+    let argc = usize::try_from(argc).ok()?;
+    let spec = command::lookup(resp::Args::new(frame, argc).next()?)?;
+    let key = spec
+        .all_keys(resp::Args::new(frame, argc).skip(1), argc)
+        .next()?;
+    Some(crc16::slot(key))
+}
+
 pub(super) fn multikey_plan(frame: &Bytes) -> Option<DegradePlan> {
     let (argc, _) = resp::scan_int_line(frame, 1)?;
     let argc = usize::try_from(argc).ok()?;
@@ -683,6 +694,23 @@ mod tests {
         s.push(1, Bytes::from_static(b"*1\r\n$1\r\nb\r\n"));
         s.push(0, Bytes::from_static(b"*1\r\n$1\r\na\r\n"));
         assert_eq!(s.merge(2, &[]).as_ref(), b"*2\r\n$1\r\na\r\n$1\r\nb\r\n");
+    }
+
+    #[test]
+    fn request_slot_reads_keyword_and_positional_keys() {
+        let frame = |args: &[&[u8]]| {
+            let mut f = Vec::new();
+            resp::write_command(&mut f, args);
+            Bytes::from(f)
+        };
+        assert_eq!(
+            request_slot(&frame(&[b"set", b"k", b"v"])),
+            Some(crc16::slot(b"k"))
+        );
+        assert_eq!(
+            request_slot(&frame(&[b"xread", b"count", b"1", b"streams", b"s1", b"0"])),
+            Some(crc16::slot(b"s1"))
+        );
     }
 
     #[test]

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -20,6 +20,7 @@ pub(super) struct InFlight {
     pub(super) expect: u32,
     pub(super) retried: bool,
     pub(super) degraded: bool,
+    pub(super) waited: bool,
     pub(super) fill: Option<Fill>,
 }
 

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -504,6 +504,7 @@ impl Session {
             expect,
             retried: false,
             degraded: false,
+            waited: false,
             fill,
         });
     }

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -3,14 +3,15 @@
 use std::cell::RefMut;
 use std::collections::VecDeque;
 use std::rc::Rc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use tokio::net::tcp::OwnedWriteHalf;
 use tokio::sync::{Notify, oneshot};
 
-use super::fanout::{Singles, multikey_plan, resend_singles, write_keys};
+use super::fanout::{Singles, multikey_plan, request_slot, resend_singles, write_keys};
 use super::link::{Fill, InFlight, InflightRing, WriterLink, mark_closed};
-use super::pipe::{parse_redirect, pipe_for, queue_on};
+use super::pipe::{parse_redirect, pipe_for, queue_on, recv_or_lost, scatter_one};
 use super::pubsub::PUBSUB_PUSH_WINDOW;
 use super::queue::ReplyQueue;
 use super::scripting::evalsha_target;
@@ -24,6 +25,11 @@ const NOSCRIPT: &[u8] = b"-NOSCRIPT No matching script";
 
 // a request taken back from the ring: frame, replies still expected, its cache ticket
 type Retry = (Bytes, u32, Option<Fill>);
+
+// an atomic slot migration's handoff leaves the two nodes briefly disagreeing on the owner: a
+// request redirected again waits between its next hops, doubling from here
+const REDIRECT_WAIT: Duration = Duration::from_millis(2);
+const REDIRECT_HOPS: u32 = 6;
 
 // out-of-order replies by sequence distance; the back slot is always Some
 #[derive(Default)]
@@ -225,6 +231,23 @@ pub(super) async fn write_loop(
                                 .await;
                             continue;
                         }
+                        if let Some((retry, slot)) = take_bounce(&link, seq) {
+                            stats::bump(&shared.wstats.redirect_waits);
+                            let gate = Rc::new(Notify::new());
+                            link.gate_slots(&[slot], &gate);
+                            let (shared, reply_q, link) =
+                                (shared.clone(), reply_q.clone(), link.clone());
+                            // detached deliberately: bounded by the hops and one backend reply each
+                            tokio::task::spawn_local(async move {
+                                let reply =
+                                    follow(&shared, client_id, link.sharded.get(), frame, retry)
+                                        .await;
+                                link.release_gates(&[slot]);
+                                gate.notify_waiters();
+                                let _ = reply_q.send(Reply::At(seq, reply));
+                            });
+                            continue;
+                        }
                         // clients believe the proxy owns every slot: never leak redirects
                         let _ = shared.refresh.send(());
                         frame = Bytes::from_static(ERR_TRYAGAIN);
@@ -416,6 +439,52 @@ fn take_retry(link: &WriterLink, seq: u64, ask: bool) -> Option<Retry> {
     entry.retried = true;
     let fill = link.detach_fill(&mut entry);
     Some((entry.frame.clone(), entry.expect, fill))
+}
+
+// a request redirected a second time waits the handoff out once, while nothing later holds a sequence
+fn take_bounce(link: &WriterLink, seq: u64) -> Option<(Retry, u16)> {
+    if !rerunnable(link, seq) {
+        return None;
+    }
+    let mut entry = entry_at(&link.inflight, seq)?;
+    if entry.waited || entry.expect != 1 {
+        return None;
+    }
+    let slot = request_slot(&entry.frame)?;
+    entry.waited = true;
+    let fill = link.detach_fill(&mut entry);
+    Some(((entry.frame.clone(), entry.expect, fill), slot))
+}
+
+// the request follows each redirect after a wait; the last answer stands
+async fn follow(
+    shared: &Rc<Shared>,
+    client_id: u64,
+    sharded: bool,
+    mut redirect: Bytes,
+    (req, _, fill): Retry,
+) -> Bytes {
+    if let Some(fill) = fill
+        && let Some(cache) = &shared.cache
+    {
+        fill.abandon(cache);
+    }
+    let mut wait = REDIRECT_WAIT;
+    for _ in 0..REDIRECT_HOPS {
+        let Some((ask, target)) = parse_redirect(&redirect) else {
+            return redirect;
+        };
+        tokio::time::sleep(wait).await;
+        wait *= 2;
+        let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
+        let rx = scatter_one(shared, target, client_id, sharded, head, req.clone()).await;
+        redirect = recv_or_lost(rx).await;
+    }
+    if parse_redirect(&redirect).is_some() {
+        Bytes::from_static(ERR_TRYAGAIN)
+    } else {
+        redirect
+    }
 }
 
 // one key-by-key resend per request, whether or not a redirect retry preceded it

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -16,6 +16,7 @@ pub struct WorkerStats {
     pub commands: AtomicU64,
     pub errors: AtomicU64,
     pub redirects: AtomicU64,
+    pub redirect_waits: AtomicU64,
     pub bytes_in: AtomicU64,
     pub bytes_out: AtomicU64,
     pub readers_exited: AtomicU64,


### PR DESCRIPTION
## Summary

Redis 8.4+ `CLUSTER MIGRATION` and Valkey 9 `CLUSTER MIGRATESLOTS` hand a slot over while the two nodes briefly disagree on its owner, so a request can be redirected from the source to the target and straight back. The proxy followed one redirect and turned the second into `TRYAGAIN`, which a client saw as an error in roughly a third of the runs under a migration moved back and forth beneath a single-key write stream (verified on both engines: the servers themselves only ever answer `MOVED`). A request redirected a second time now waits (2 ms, doubling) before each of up to six further hops, gated on its slot and only while nothing later of the session holds a sequence, so ordering is unchanged; `INFO` counts these as `redirect_waits`.

## Evidence

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (95) clean.
- The new integration test churns INCR/GET through the proxy while the slot migrates back and forth twice (20 000 keys of 1 KB) and asserts no error and no lost increment: 20/20 runs on Valkey 9.1.2 and 20/20 on Redis 8.10.1 with this change, versus 8/10 and 5/10 before it.
- Local matrix: redis 6.2 / 7.4 / 8.2 / 8.10 + valkey 9.1 × nocache / cache / autocache — 15/15 green (88 integration tests).
- Testbed (Redis 8.10.1 / Valkey 9.1.1): IT × 8 proxy modes green; the mt-proxy functional suite at 149 (default) and 149 (shard) passed, unchanged from master.
- Independent review: converged.
