### PR TITLE
review: simplify the cluster-databases and pubsub batch

### DIFF
--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -79,7 +79,6 @@ pub(super) struct WriterLink {
 }
 
 impl WriterLink {
-    /// The newest live watch generation of `slot`.
     /// The newest generation of a slot in the session's database; a watch armed under
     /// another database (before a SELECT) no longer routes the session's commands.
     pub(super) fn generation_in_db(&self, slot: u16) -> Option<Rc<Watched>> {

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -72,7 +72,7 @@ impl Session {
             Some(slot) => {
                 state.slot = Some(slot);
                 state.bytes += frame.len();
-                if self.link.db.get() == 0 && self.shared.cache.is_some() && spec.is_write() {
+                if self.cache().is_some() && spec.is_write() {
                     write_keys(spec, &frame, argc, |k| {
                         state.write_keys.push(frame.slice_ref(k))
                     });
@@ -211,6 +211,12 @@ impl Session {
             self.set_db(0);
             let seq = self.alloc_seq();
             self.deliver_select(seq, Bytes::from_static(resp::OK), changed);
+            return;
+        }
+        // re-selecting the current database is already validated: answer without a probe
+        if index == i64::from(self.link.db.get()) {
+            let seq = self.alloc_seq();
+            self.emit_at(seq, Bytes::from_static(resp::OK));
             return;
         }
         let seq = self.alloc_seq();

--- a/src/client/pubsub.rs
+++ b/src/client/pubsub.rs
@@ -493,10 +493,9 @@ fn absorb_ack(link: &WriterLink, frame: &[u8]) -> usize {
     void
 }
 
-fn reconcile_push(link: &WriterLink, frame: &[u8]) -> bool {
-    match push_parts(frame) {
-        Some((kind, name)) => link.subs.borrow_mut().confirm(kind, name),
-        None => false,
+fn reconcile_push(link: &WriterLink, frame: &[u8]) {
+    if let Some((kind, name)) = push_parts(frame) {
+        link.subs.borrow_mut().confirm(kind, name);
     }
 }
 

--- a/src/client/users.rs
+++ b/src/client/users.rs
@@ -65,14 +65,13 @@ impl Session {
                 spec.name
             )));
         }
-        for key in spec
-            .all_keys(resp::Args::new(frame, argc).skip(1), argc)
-            .filter(|_| !spec.is_pubsub())
-        {
-            if !user.may_touch(key) {
-                drop(user);
-                self.deny("key", spec.name, key, None);
-                return Some(Bytes::from_static(ERR_NOPERM_KEY));
+        if !spec.is_pubsub() {
+            for key in spec.all_keys(resp::Args::new(frame, argc).skip(1), argc) {
+                if !user.may_touch(key) {
+                    drop(user);
+                    self.deny("key", spec.name, key, None);
+                    return Some(Bytes::from_static(ERR_NOPERM_KEY));
+                }
             }
         }
         let mut channels = resp::Args::new(frame, argc).skip(1);


### PR DESCRIPTION
## Summary

Post-landing cleanup of the shard-pubsub / atomic-migration / cluster-databases batch, from a four-lens simplify pass and a loc-justify audit. No behavior change beyond one optimisation:

- `SELECT n` re-selecting the database the session is already on answers `+OK` without the `CONFIG GET cluster-databases` probe — a client library or connection pooler that selects on every checkout no longer pays a backend round-trip for a no-op.
- The ACL key check hoists its `is_pubsub` guard out of the per-key loop (evaluated once, not per key).
- `queue_multi` collects write keys through `Session::cache()`, which already gates on database 0.
- `reconcile_push` returns `()`; its `bool` was unused once the pubsub reservation accounting moved into `absorb_ack`.
- A stale doc line left by the `generation_in_db` rename is removed.

## Evidence

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (95) clean.
- Local matrix: redis 6.2 / 7.4 / 8.2 / 8.10 + valkey 9.1 × nocache / cache / autocache — 15/15 green.
- Testbed (Redis 8.10.1 / Valkey 9.1.1): IT × 8 proxy modes green; the mt-proxy functional suite at 149 (default) and 147 (shard) passed, unchanged from master.
