### PR TITLE
review: layout and a redundant startup clone

### DIFF
--- a/src/script.rs
+++ b/src/script.rs
@@ -12,11 +12,6 @@ pub struct Scripts {
     inner: Mutex<Inner>,
 }
 
-struct Inner {
-    flushes: u64,
-    bodies: HashMap<Box<[u8]>, Bytes>,
-}
-
 impl Scripts {
     pub fn new() -> Arc<Scripts> {
         Arc::new(Scripts {
@@ -59,6 +54,11 @@ impl Scripts {
     fn lock(&self) -> MutexGuard<'_, Inner> {
         self.inner.lock().unwrap_or_else(PoisonError::into_inner)
     }
+}
+
+struct Inner {
+    flushes: u64,
+    bodies: HashMap<Box<[u8]>, Bytes>,
 }
 
 #[cfg(test)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -228,11 +228,10 @@ pub fn run(cfg: Config) -> Result<(), String> {
             .spawn(move || worker_thread(ctx, conn_rx, shard))
             .map_err(|e| format!("spawn worker: {e}"))?;
     }
-    let acceptor_cfg = cfg.clone();
     let acceptor_stats = stats.clone();
     std::thread::Builder::new()
         .name("mithril-accept".to_string())
-        .spawn(move || acceptor_thread(listener, acceptor_cfg, acceptor_stats, conn_txs))
+        .spawn(move || acceptor_thread(listener, cfg, acceptor_stats, conn_txs))
         .map_err(|e| format!("spawn acceptor: {e}"))?;
 
     wait_for_signal();


### PR DESCRIPTION
## Summary

Batch-end whole-repo hygiene sweep (ownership lens ×2, style self-check, loc-justify), all read full-file. Ownership clean across all 30 source files (0 defects; hot path allocation-free bar one required in-flight `Bytes` refcount). loc-justify: nothing to cut (clippy clean, every guard reachable under the Redis/Valkey matrix). Two style items, one fixed here:

- `script.rs`: the private `Inner` sat between `Scripts` and its `impl`; glue the type to its impl and put `Inner` below.
- `server.rs`: move `cfg` into the acceptor spawn instead of cloning it — nothing uses it afterward.

(The one `unreachable!` in `multikey.rs` `SlotHasher::write` is kept: a trait-mandated method, self-documented, and outside the `unwrap_used`/`expect_used` lints.)

## Evidence

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (95) clean.
- Local matrix: redis 6.2 / 7.4 / 8.2 / 8.10 + valkey 9.1 × nocache / cache / autocache — 15/15 green.
- Testbed: IT × 8 proxy modes green; mt-proxy functional suite at 149 (default) and 149 (shard) unchanged from master.
