### PR TITLE
fix: ride out failovers and migrations whole, reload redirected scripts, free stalled sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ See [`mithril.conf.sample`](mithril.conf.sample) and the
 make test lint fmt-check   # the CI gate
 ```
 
-The integration suite lives in [`it/`](it/): 92 dockerized tests driving a
+The integration suite lives in [`it/`](it/): 95 dockerized tests driving a
 real 3-master/3-replica cluster through the proxy with redis-py — including
 live slot migrations (legacy and atomic) under traffic — run against redis 6.2
 through 8.10 and valkey 9.1 in every mode combination (`backend-sharding`,

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -42,15 +42,21 @@
   the multi-key case below.
 - A keyless write broadcast (FLUSHALL, FUNCTION LOAD) that a master demoted
   by a failover answers `READONLY` is resent, after a topology refresh, to
-  the masters the cluster reports now, with the same waits.
+  the new master of that node's shard, with the same waits; the replies of
+  the other masters stand, so a FUNCTION LOAD is never repeated where it
+  already took. The session waits for a broadcast's replies, so a later
+  command of the same client never overtakes it.
 - A multi-key command the server refuses mid-migration (`TRYAGAIN`) is
   first retried whole with the same waits, so under an atomic migration a
   same-slot MSET/DEL stays atomic; only when the refusal outlasts the waits
   (a legacy migration with the keys split across source and target) is it
-  re-issued key by key, no longer atomic, and
-  a pipelined client with requests queued behind such a command receives
-  one `TRYAGAIN` for it before the session switches that slot to the
-  ordered path. PFCOUNT is never split this way.
+  re-issued key by key, no longer atomic. A redirect that outlasts the waits
+  ends the command with `TRYAGAIN` instead, never split. A pipelined client
+  with requests queued behind such a command receives one `TRYAGAIN` for it
+  before the session switches that slot to the ordered path. PFCOUNT is
+  never split this way.
+- An EVALSHA that meets `NOSCRIPT` after a redirect is reloaded at the node
+  the redirect named, while the topology refresh is still pending.
 - After a failover the proxy's topology lags by at most one refresh
   (`topology-refresh-secs`, or the first redirect it sees): in that window a
   cluster-wide command can reach a demoted node and return `READONLY`, and a

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -40,9 +40,14 @@
   and the client sees only its reply. A pipelined client with later
   requests already in flight receives `TRYAGAIN` for it instead, as with
   the multi-key case below.
-- A multi-key command whose keys are split across a migrating slot
-  (`TRYAGAIN` from the server) is re-issued key by key, so it completes
-  through the migration; a same-slot MSET/DEL is then no longer atomic, and
+- A keyless write broadcast (FLUSHALL, FUNCTION LOAD) that a master demoted
+  by a failover answers `READONLY` is resent, after a topology refresh, to
+  the masters the cluster reports now, with the same waits.
+- A multi-key command the server refuses mid-migration (`TRYAGAIN`) is
+  first retried whole with the same waits, so under an atomic migration a
+  same-slot MSET/DEL stays atomic; only when the refusal outlasts the waits
+  (a legacy migration with the keys split across source and target) is it
+  re-issued key by key, no longer atomic, and
   a pipelined client with requests queued behind such a command receives
   one `TRYAGAIN` for it before the session switches that slot to the
   ordered path. PFCOUNT is never split this way.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -31,13 +31,17 @@ route by their first key (or any master when they declare none).
 MGET, MSET, DEL, UNLINK, EXISTS, TOUCH and PFCOUNT split per slot, execute
 in parallel, and merge: MGET order-preserving, MSET all-OK, the rest summed.
 A redirected part is retried once against its new owner before merging.
-A part answered `TRYAGAIN` (its keys split across a migrating slot) is
-re-issued key by key so each request follows `ASK`; a single-slot multi-key
-command degrades the same way when nothing is queued behind it, otherwise
-the `TRYAGAIN` reaches the client and the session routes that slot's
-multi-key commands through the ordered fan-out path until the topology
-changes. During a migration a same-slot MSET or DEL therefore executes as
-independent single-key commands rather than one atomic command. PFCOUNT is
+A part answered `TRYAGAIN` is first retried whole with short waits (2 ms,
+doubling, up to six), which sees an atomic slot migration through with the
+command intact; only when the refusal outlasts the waits (a legacy migration
+with the keys split across source and target) is it re-issued key by key so
+each request follows `ASK`, and a same-slot MSET or DEL then executes as
+independent single-key commands rather than one atomic command. A redirect
+that outlasts the waits ends the command with `TRYAGAIN`. A single-slot
+multi-key command takes that path when nothing is queued behind it,
+otherwise the `TRYAGAIN` reaches the client and the session routes that
+slot's multi-key commands through the ordered fan-out path until the
+topology changes. PFCOUNT is
 the exception: over several keys it counts one union, so it is not
 re-issued key by key and the `TRYAGAIN` reaches the client. Cluster-wide
 commands (DBSIZE, FLUSHALL, SCAN) wait for every pending fan-out first.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -56,8 +56,9 @@ SCRIPT LOAD reaches every node (scripts do not replicate since Redis 7) and
 returns the sha once all agree; SCRIPT EXISTS answers true only for a sha
 every master holds; SCRIPT FLUSH clears every node. The proxy remembers the
 body of every script it loaded, so an EVALSHA that meets `NOSCRIPT` on a
-node — after a restart or a flush behind the proxy's back — reloads it there
-and reruns transparently when nothing later from that session is in flight.
+node — after a restart or a flush behind the proxy's back, redirected there
+or not — reloads it there and reruns transparently when nothing later from
+that session is in flight.
 FUNCTION LOAD/DELETE/FLUSH/RESTORE broadcast to the masters (libraries
 replicate); FUNCTION LIST/DUMP/STATS/HELP and SCRIPT HELP/SHOW answer from
 one master. SCRIPT KILL, FUNCTION KILL and SCRIPT DEBUG are not proxied.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -66,11 +66,16 @@ memtier_benchmark, redis-benchmark.
   (elements present in several slots count more than once); within one slot
   it is the server's exact union.
 - During a slot migration a same-slot MSET or DEL that the server refuses
-  with `TRYAGAIN` executes as independent single-key commands; a
-  concurrent reader can observe it half applied.
-- After a failover, until the next topology refresh (at most
-  `topology-refresh-secs` or the first redirect seen), a cluster-wide
-  command may reach a demoted node and return `READONLY`.
+  with `TRYAGAIN` is retried whole once the handoff settles (2 ms, doubling,
+  up to six waits), so under an atomic migration it stays atomic; only a
+  legacy migration whose keys really sit on two nodes still executes it as
+  independent single-key commands, which a concurrent reader can observe
+  half applied.
+- After a failover a cluster-wide write (FLUSHALL, FUNCTION LOAD) can reach
+  a demoted node and be answered `READONLY`; the proxy then refreshes the
+  topology and resends it to the masters the cluster reports, up to six
+  times with short waits, and only a refresh slower than that leaves the
+  client the `READONLY`.
 - Server-management commands are not proxied: WAIT, DEBUG, LATENCY, MEMORY,
   SHUTDOWN, FAILOVER, REPLICAOF, SAVE/BGSAVE, MIGRATE and similar return
   unknown-command. OBJECT routes by its key.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -45,9 +45,9 @@ memtier_benchmark, redis-benchmark.
   parameter.
 - SCRIPT KILL, SCRIPT DEBUG and FUNCTION KILL are not proxied. The
   transparent reload on `NOSCRIPT` covers scripts the proxy loaded itself,
-  and only while nothing later from the same session is in flight (a
-  pipelined EVALSHA, or one that was already redirected, gets the
-  `NOSCRIPT` and the client's own EVAL fallback applies). FUNCTION
+  redirected or not, and only while nothing later from the same session is
+  in flight (a pipelined EVALSHA gets the `NOSCRIPT` and the client's own
+  EVAL fallback applies). FUNCTION
   commands reach the masters that own slots; a node needs its libraries
   loaded before slots move to it, as with any client.
 - Shard pubsub: the shard channels of one client connection must live on
@@ -70,12 +70,13 @@ memtier_benchmark, redis-benchmark.
   up to six waits), so under an atomic migration it stays atomic; only a
   legacy migration whose keys really sit on two nodes still executes it as
   independent single-key commands, which a concurrent reader can observe
-  half applied.
+  half applied. A redirect that outlasts the waits ends it with `TRYAGAIN`.
 - After a failover a cluster-wide write (FLUSHALL, FUNCTION LOAD) can reach
   a demoted node and be answered `READONLY`; the proxy then refreshes the
-  topology and resends it to the masters the cluster reports, up to six
+  topology and resends it to the new master of that shard only, up to six
   times with short waits, and only a refresh slower than that leaves the
-  client the `READONLY`.
+  client the `READONLY`. The session waits for the outcome before it runs
+  the client's next command.
 - Server-management commands are not proxied: WAIT, DEBUG, LATENCY, MEMORY,
   SHUTDOWN, FAILOVER, REPLICAOF, SAVE/BGSAVE, MIGRATE and similar return
   unknown-command. OBJECT routes by its key.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,6 +1,6 @@
 # Compatibility
 
-The 92-test integration suite runs against each backend, in every mode
+The 95-test integration suite runs against each backend, in every mode
 combination (`backend-sharding`, `reply-cache`), with full cluster
 teardown/recreate between versions; it includes a live slot migration
 (CLUSTER SETSLOT MIGRATING/IMPORTING + MIGRATE) under multi-key commands

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -46,9 +46,9 @@ retried whole with the same waits, which keeps a same-slot MSET/DEL atomic
 under an atomic migration, and only re-issued key by key when the refusal
 outlasts the waits (a legacy migration with the keys split across source
 and target). A keyless write broadcast (FLUSHALL, FUNCTION LOAD) that a
-demoted master answers `READONLY` after a failover is resent to the
-current masters after a topology refresh, with the same waits; every such
-wait counts under `redirect_waits`.
+demoted master answers `READONLY` after a failover is resent, after a
+topology refresh, to the new master of that shard, with the same waits;
+every such wait counts under `redirect_waits`.
 If a slot has no known owner the client receives `-CLUSTERDOWN`; if a retry
 is not possible the client receives `-TRYAGAIN` and should back off and
 retry.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,8 +41,14 @@ against atomic slot migrations (Redis 8.4+ `CLUSTER MIGRATION`, Valkey 9
 `CLUSTER MIGRATESLOTS`), whose handoff can redirect a request back and
 forth for a moment: such a request follows the redirects with short waits
 between them, and `INFO` counts these as `redirect_waits`. Multi-key
-commands that the server refuses mid-migration (`TRYAGAIN`, keys split
-across source and target) are re-issued key by key, so they complete too.
+commands that the server refuses mid-migration (`TRYAGAIN`) are first
+retried whole with the same waits, which keeps a same-slot MSET/DEL atomic
+under an atomic migration, and only re-issued key by key when the refusal
+outlasts the waits (a legacy migration with the keys split across source
+and target). A keyless write broadcast (FLUSHALL, FUNCTION LOAD) that a
+demoted master answers `READONLY` after a failover is resent to the
+current masters after a topology refresh, with the same waits; every such
+wait counts under `redirect_waits`.
 If a slot has no known owner the client receives `-CLUSTERDOWN`; if a retry
 is not possible the client receives `-TRYAGAIN` and should back off and
 retry.

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -1017,12 +1017,15 @@ def test_cache_mget_hits_and_read_your_writes(cache_proxy, key_prefix):
 
 
 def _cached_mget(r, keys):
-    for _ in range(20):
+    deadline = time.time() + 5
+    while True:
         before = int(r.info()["cache_hits"])
         reply = r.mget(*keys)
         if int(r.info()["cache_hits"]) > before:
             return reply
-    pytest.fail("MGET never hit the reply cache")
+        if time.time() > deadline:
+            pytest.fail("MGET never hit the reply cache")
+        time.sleep(0.05)
 
 
 def test_cache_mget_converges_after_external_write(cache_proxy, cluster_direct, key_prefix):

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -957,14 +957,15 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
     finally:
         stop.set()
         worker.join(30)
-        if master.info("replication")["role"] != "master" and synced(master):
+        restored = master.info("replication")["role"] == "master"
+        if not restored and synced(master):
             master.execute_command("CLUSTER", "FAILOVER", "TAKEOVER")
-            role_is(master, "master")
-            role_is(replica, "slave")
+            restored = role_is(master, "master") and role_is(replica, "slave")
         master.close()
         replica.close()
     assert errors == []
     assert loads[0] > 0
+    assert restored, "the original master was not restored"
 
 
 def test_evalsha_reloads_after_a_redirect(r, cluster_direct, key_prefix):

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -864,32 +864,40 @@ def test_mset_stays_atomic_under_slot_migration(r, cluster_direct, new_conn, key
     src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
     dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
     assert r.set(probe, "p")
+    assert r.mset({a: "0", b: "0"})
     stop, errors, torn, rounds = threading.Event(), [], [], [0]
 
-    def churn():
+    def write():
         c = new_conn()
         n = 0
         while not stop.is_set() and len(errors) < 20:
             n += 1
             try:
                 c.mset({a: str(n), b: str(n)})
-                va, vb = c.mget(a, b)
-                if va != vb:
-                    torn.append((va, vb))
                 rounds[0] = n
             except redis.exceptions.RedisError as e:
                 errors.append(repr(e))
 
-    worker = threading.Thread(target=churn)
-    worker.start()
+    def watch():
+        c = new_conn()
+        while not stop.is_set() and len(errors) < 20:
+            try:
+                va, vb = c.mget(a, b)
+                if va != vb:
+                    torn.append((va, vb))
+            except redis.exceptions.RedisError as e:
+                errors.append(repr(e))
+
+    threads = [threading.Thread(target=write), threading.Thread(target=watch)]
+    for t in threads:
+        t.start()
     try:
         for source, target in [(src, dst), (dst, src)] * 2:
             _migrate_slot(source, target, slot, probe)
-        stop.set()
-        worker.join(30)
     finally:
         stop.set()
-        worker.join(30)
+        for t in threads:
+            t.join(30)
         if _moved(src, probe):
             _migrate_slot(dst, src, slot, probe)
         r.delete(a, b, probe)
@@ -908,7 +916,8 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
         pytest.skip("the slot's master has no replica")
     master = redis.Redis(host=nodes[0].host, port=nodes[0].port, decode_responses=True)
     replica = redis.Redis(host=nodes[1].host, port=nodes[1].port, decode_responses=True)
-    lib = f"#!lua name={key_prefix.replace(':', '_')}\nredis.register_function('f_{key_prefix.replace(':', '_')}', function() return 1 end)"
+    name = key_prefix.replace(":", "_")
+    lib = f"#!lua name={name}\nredis.register_function('f_{name}', function() return 1 end)"
     stop, errors, loads = threading.Event(), [], [0]
 
     def churn():
@@ -947,6 +956,31 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
     assert loads[0] > 0
 
 
+def test_evalsha_reloads_after_a_redirect(r, cluster_direct, key_prefix):
+    _needs(cluster_direct, (8, 4))
+    key = f"{key_prefix}:reload"
+    slot = key_slot(key.encode())
+    src_node = cluster_direct.get_node_from_key(key)
+    dst_node = next(
+        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
+    )
+    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
+    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    sha = r.script_load("return redis.call('set', KEYS[1], ARGV[1])")
+    assert r.evalsha(sha, 1, key, "v1") == "OK"
+    try:
+        _migrate_slot(src, dst, slot, key)
+        dst.script_flush()
+        assert r.evalsha(sha, 1, key, "v2") == "OK"
+        assert r.get(key) == "v2"
+    finally:
+        if _moved(src, key):
+            _migrate_slot(dst, src, slot, key)
+        r.delete(key)
+        src.close()
+        dst.close()
+
+
 def _slot_nodes(cluster_direct, slot):
     deadline = time.time() + 10
     while True:
@@ -962,14 +996,8 @@ def test_cache_mget_hits_and_read_your_writes(cache_proxy, key_prefix):
     a, b, c = f"{{{key_prefix}}}a", f"{{{key_prefix}}}b", f"{key_prefix}:c"
     assert key_slot(c.encode()) != key_slot(a.encode())
     assert r.mset({a: "1", b: "2", c: "3"})
-    assert r.mget(a, b) == ["1", "2"]
-    before = int(r.info()["cache_hits"])
-    assert r.mget(a, b) == ["1", "2"]
-    assert int(r.info()["cache_hits"]) > before
-    assert r.mget(a, b, c) == ["1", "2", "3"]
-    before = int(r.info()["cache_hits"])
-    assert r.mget(a, b, c) == ["1", "2", "3"]
-    assert int(r.info()["cache_hits"]) > before
+    assert _cached_mget(r, [a, b]) == ["1", "2"]
+    assert _cached_mget(r, [a, b, c]) == ["1", "2", "3"]
     assert r.set(a, "11")
     assert r.mget(a, b, c) == ["11", "2", "3"]
     assert r.mset({b: "22", c: "33"})
@@ -977,6 +1005,15 @@ def test_cache_mget_hits_and_read_your_writes(cache_proxy, key_prefix):
     assert r.delete(c) == 1
     assert r.mget(a, b, c) == ["11", "22", None]
     assert r.mget(c, a) == [None, "11"]
+
+
+def _cached_mget(r, keys):
+    for _ in range(20):
+        before = int(r.info()["cache_hits"])
+        reply = r.mget(*keys)
+        if int(r.info()["cache_hits"]) > before:
+            return reply
+    pytest.fail("MGET never hit the reply cache")
 
 
 def test_cache_mget_converges_after_external_write(cache_proxy, cluster_direct, key_prefix):

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -948,8 +948,9 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
     worker = threading.Thread(target=churn)
     worker.start()
     try:
-        assert replica.execute_command("CLUSTER FAILOVER")
+        assert replica.execute_command("CLUSTER", "FAILOVER", "TAKEOVER")
         assert role_is(replica, "master"), "failover did not complete"
+        assert role_is(master, "slave"), "the old master was not demoted"
         time.sleep(0.5)
         stop.set()
         worker.join(30)
@@ -957,8 +958,9 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
         stop.set()
         worker.join(30)
         if master.info("replication")["role"] != "master" and synced(master):
-            master.execute_command("CLUSTER FAILOVER")
+            master.execute_command("CLUSTER", "FAILOVER", "TAKEOVER")
             role_is(master, "master")
+            role_is(replica, "slave")
         master.close()
         replica.close()
     assert errors == []

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -853,6 +853,99 @@ def test_atomic_slot_migration_under_traffic(r, cluster_direct, new_conn, key_pr
     assert last[0] > 0 and int(final) == last[0]
 
 
+def test_mset_stays_atomic_under_slot_migration(r, cluster_direct, new_conn, key_prefix):
+    _needs(cluster_direct, (8, 4))
+    a, b, probe = f"{{{key_prefix}}}:ma", f"{{{key_prefix}}}:mb", f"{{{key_prefix}}}:mp"
+    slot = key_slot(probe.encode())
+    src_node = cluster_direct.get_node_from_key(probe)
+    dst_node = next(
+        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
+    )
+    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
+    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    assert r.set(probe, "p")
+    stop, errors, torn, rounds = threading.Event(), [], [], [0]
+
+    def churn():
+        c = new_conn()
+        n = 0
+        while not stop.is_set() and len(errors) < 20:
+            n += 1
+            try:
+                c.mset({a: str(n), b: str(n)})
+                va, vb = c.mget(a, b)
+                if va != vb:
+                    torn.append((va, vb))
+                rounds[0] = n
+            except redis.exceptions.RedisError as e:
+                errors.append(repr(e))
+
+    worker = threading.Thread(target=churn)
+    worker.start()
+    try:
+        for source, target in [(src, dst), (dst, src)] * 2:
+            _migrate_slot(source, target, slot, probe)
+        stop.set()
+        worker.join(30)
+    finally:
+        stop.set()
+        worker.join(30)
+        if _moved(src, probe):
+            _migrate_slot(dst, src, slot, probe)
+        r.delete(a, b, probe)
+        src.close()
+        dst.close()
+    assert errors == []
+    assert torn == []
+    assert rounds[0] > 0
+
+
+def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_prefix):
+    _needs(cluster_direct, (7, 0))
+    k = f"{key_prefix}:fo"
+    nodes = cluster_direct.nodes_manager.slots_cache[key_slot(k.encode())]
+    assert len(nodes) > 1, "the slot's master has no replica"
+    master = redis.Redis(host=nodes[0].host, port=nodes[0].port, decode_responses=True)
+    replica = redis.Redis(host=nodes[1].host, port=nodes[1].port, decode_responses=True)
+    lib = f"#!lua name={key_prefix.replace(':', '_')}\nredis.register_function('f_{key_prefix.replace(':', '_')}', function() return 1 end)"
+    stop, errors, loads = threading.Event(), [], [0]
+
+    def churn():
+        c = new_conn()
+        while not stop.is_set() and len(errors) < 20:
+            try:
+                c.execute_command("FUNCTION", "LOAD", "REPLACE", lib)
+                loads[0] += 1
+            except redis.exceptions.RedisError as e:
+                errors.append(repr(e))
+
+    def role_is(node, role):
+        for _ in range(200):
+            if node.info("replication")["role"] == role:
+                return True
+            time.sleep(0.05)
+        return False
+
+    worker = threading.Thread(target=churn)
+    worker.start()
+    try:
+        assert replica.execute_command("CLUSTER FAILOVER")
+        assert role_is(replica, "master"), "failover did not complete"
+        time.sleep(0.5)
+        stop.set()
+        worker.join(30)
+    finally:
+        stop.set()
+        worker.join(30)
+        if master.info("replication")["role"] != "master":
+            master.execute_command("CLUSTER FAILOVER")
+            role_is(master, "master")
+        master.close()
+        replica.close()
+    assert errors == []
+    assert loads[0] > 0
+
+
 def test_cache_mget_hits_and_read_your_writes(cache_proxy, key_prefix):
     r = cache_proxy
     a, b, c = f"{{{key_prefix}}}a", f"{{{key_prefix}}}b", f"{key_prefix}:c"

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -739,12 +739,7 @@ def test_multikey_survives_a_migrating_slot(r, cluster_direct, key_prefix):
     a, b, other = f"{{{key_prefix}}}a", f"{{{key_prefix}}}b", f"{key_prefix}:other"
     slot = key_slot(a.encode())
     assert key_slot(other.encode()) != slot
-    src_node = cluster_direct.get_node_from_key(a)
-    dst_node = next(
-        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
-    )
-    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
-    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    src_node, dst_node, src, dst = _shard_pair(cluster_direct, a)
     src_id = src.execute_command("CLUSTER MYID")
     dst_id = dst.execute_command("CLUSTER MYID")
     assert r.mset({a: "1", b: "2", other: "3"})
@@ -781,6 +776,26 @@ def test_multikey_survives_a_migrating_slot(r, cluster_direct, key_prefix):
         dst.close()
 
 
+def _shard_pair(cluster_direct, key):
+    """The master owning `key` and another master, as nodes and as direct clients."""
+    src_node = cluster_direct.get_node_from_key(key)
+    dst_node = next(
+        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
+    )
+    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
+    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    return src_node, dst_node, src, dst
+
+
+def _until(cond, seconds=30):
+    deadline = time.time() + seconds
+    while not cond():
+        if time.time() > deadline:
+            return False
+        time.sleep(0.05)
+    return True
+
+
 def _migrate_slot(source, target, slot, probe):
     """Atomic slot migration of `slot` to `target`, waited until `source` redirects."""
     if "valkey_version" in target.info("server"):
@@ -808,12 +823,7 @@ def test_atomic_slot_migration_under_traffic(r, cluster_direct, new_conn, key_pr
     counter = f"{{{key_prefix}}}:n"
     keys = [f"{{{key_prefix}}}:{i}" for i in range(20000)]
     slot = key_slot(counter.encode())
-    src_node = cluster_direct.get_node_from_key(counter)
-    dst_node = next(
-        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
-    )
-    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
-    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    _, _, src, dst = _shard_pair(cluster_direct, counter)
     bulk = new_conn()
     pipe = bulk.pipeline(transaction=False)
     for k in keys:
@@ -857,12 +867,7 @@ def test_mset_stays_atomic_under_slot_migration(r, cluster_direct, new_conn, key
     _needs(cluster_direct, (8, 4))
     a, b, probe = f"{{{key_prefix}}}:ma", f"{{{key_prefix}}}:mb", f"{{{key_prefix}}}:mp"
     slot = key_slot(probe.encode())
-    src_node = cluster_direct.get_node_from_key(probe)
-    dst_node = next(
-        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
-    )
-    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
-    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    _, _, src, dst = _shard_pair(cluster_direct, probe)
     assert r.set(probe, "p")
     assert r.mset({a: "0", b: "0"})
     stop, errors, torn, rounds = threading.Event(), [], [], [0]
@@ -930,19 +935,14 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
                 errors.append(repr(e))
 
     def role_is(node, role):
-        for _ in range(600):
-            if node.info("replication")["role"] == role:
-                return True
-            time.sleep(0.05)
-        return False
+        return _until(lambda: node.info("replication")["role"] == role)
 
     def synced(node):
-        for _ in range(600):
+        def caught_up():
             info = node.info("replication")
-            if info.get("master_link_status") == "up" and not info.get("master_sync_in_progress"):
-                return True
-            time.sleep(0.05)
-        return False
+            return info.get("master_link_status") == "up" and not info.get("master_sync_in_progress")
+
+        return _until(caught_up)
 
     assert synced(replica), "the replica never caught up with its master"
     worker = threading.Thread(target=churn)
@@ -972,12 +972,7 @@ def test_evalsha_reloads_after_a_redirect(r, cluster_direct, key_prefix):
     _needs(cluster_direct, (8, 4))
     key = f"{key_prefix}:reload"
     slot = key_slot(key.encode())
-    src_node = cluster_direct.get_node_from_key(key)
-    dst_node = next(
-        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
-    )
-    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
-    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    _, _, src, dst = _shard_pair(cluster_direct, key)
     sha = r.script_load("return redis.call('set', KEYS[1], ARGV[1])")
     assert r.evalsha(sha, 1, key, "v1") == "OK"
     try:
@@ -1887,12 +1882,7 @@ def test_sharded_channel_follows_its_slot_away(cluster_direct, raw_socket, key_p
     _needs(cluster_direct, (7, 0))
     ch = f"{key_prefix}:{{mv}}:news"
     slot = key_slot(ch.encode())
-    src_node = cluster_direct.get_node_from_key(ch)
-    dst_node = next(
-        n for n in cluster_direct.get_primaries() if (n.host, n.port) != (src_node.host, src_node.port)
-    )
-    src = redis.Redis(host=src_node.host, port=src_node.port, decode_responses=True)
-    dst = redis.Redis(host=dst_node.host, port=dst_node.port, decode_responses=True)
+    _, _, src, dst = _shard_pair(cluster_direct, ch)
     src_id, dst_id = src.execute_command("CLUSTER MYID"), dst.execute_command("CLUSTER MYID")
     s = raw_socket()
     reader = _RespReader(s)

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -903,8 +903,9 @@ def test_mset_stays_atomic_under_slot_migration(r, cluster_direct, new_conn, key
 def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_prefix):
     _needs(cluster_direct, (7, 0))
     k = f"{key_prefix}:fo"
-    nodes = cluster_direct.nodes_manager.slots_cache[key_slot(k.encode())]
-    assert len(nodes) > 1, "the slot's master has no replica"
+    nodes = _slot_nodes(cluster_direct, key_slot(k.encode()))
+    if len(nodes) < 2:
+        pytest.skip("the slot's master has no replica")
     master = redis.Redis(host=nodes[0].host, port=nodes[0].port, decode_responses=True)
     replica = redis.Redis(host=nodes[1].host, port=nodes[1].port, decode_responses=True)
     lib = f"#!lua name={key_prefix.replace(':', '_')}\nredis.register_function('f_{key_prefix.replace(':', '_')}', function() return 1 end)"
@@ -944,6 +945,16 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
         replica.close()
     assert errors == []
     assert loads[0] > 0
+
+
+def _slot_nodes(cluster_direct, slot):
+    deadline = time.time() + 10
+    while True:
+        nodes = cluster_direct.nodes_manager.slots_cache[slot]
+        if len(nodes) > 1 or time.time() > deadline:
+            return nodes
+        time.sleep(0.5)
+        cluster_direct.nodes_manager.initialize()
 
 
 def test_cache_mget_hits_and_read_your_writes(cache_proxy, key_prefix):

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -930,12 +930,21 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
                 errors.append(repr(e))
 
     def role_is(node, role):
-        for _ in range(200):
+        for _ in range(600):
             if node.info("replication")["role"] == role:
                 return True
             time.sleep(0.05)
         return False
 
+    def synced(node):
+        for _ in range(600):
+            info = node.info("replication")
+            if info.get("master_link_status") == "up" and not info.get("master_sync_in_progress"):
+                return True
+            time.sleep(0.05)
+        return False
+
+    assert synced(replica), "the replica never caught up with its master"
     worker = threading.Thread(target=churn)
     worker.start()
     try:
@@ -947,7 +956,7 @@ def test_keyless_write_rides_out_a_failover(r, cluster_direct, new_conn, key_pre
     finally:
         stop.set()
         worker.join(30)
-        if master.info("replication")["role"] != "master":
+        if master.info("replication")["role"] != "master" and synced(master):
             master.execute_command("CLUSTER FAILOVER")
             role_is(master, "master")
         master.close()

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -56,9 +56,7 @@ impl Session {
             let reply = blocking_round(&shared, db, slot, frame, None, false).await;
             let _ = reply_q.send(Reply::At(seq, reply));
         });
-        let mut blocking = self.link.blocking.borrow_mut();
-        blocking.retain(|(_, t)| !t.is_finished());
-        blocking.push((seq, task));
+        self.link.track(seq, task);
     }
 }
 

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -11,6 +11,7 @@ use super::writer::{REDIRECT_HOPS, REDIRECT_WAIT};
 use crate::multikey;
 use crate::resp;
 use crate::stats;
+use crate::topology::Topology;
 
 /// Which nodes a broadcast reaches.
 #[derive(Clone, Copy)]
@@ -32,6 +33,8 @@ pub(super) enum Gather {
 }
 
 impl Session {
+    // the session waits for the replies: a later command of the same client never overtakes
+    // a keyless write, not even one resent after a failover
     pub(super) async fn run_broadcast(
         &self,
         frame: Bytes,
@@ -41,8 +44,7 @@ impl Session {
         remember: Option<(Bytes, u64)>,
     ) {
         let seq = self.alloc_seq();
-        let shared = self.shared.clone();
-        let reply_q = self.reply_q.clone();
+        let shared = &self.shared;
         let topo = shared.topo.load_full();
         let lane = self.lane();
         let all;
@@ -59,45 +61,63 @@ impl Session {
         let mut receivers = Vec::with_capacity(nodes.len());
         for &i in nodes {
             let addr = &topo.nodes[i as usize].addr;
-            receivers.push(scatter_one(&shared, addr, lane, None, frame.clone()).await);
+            receivers.push(scatter_one(shared, addr, lane, None, frame.clone()).await);
         }
-        // detached deliberately: completion is bounded by backend replies
-        tokio::task::spawn_local(async move {
-            let mut replies = collect(receivers).await;
-            // a master demoted since the last refresh answers a keyless write READONLY: ask for
-            // the topology again and send once more to the masters it reports, a few times
-            let mut wait = REDIRECT_WAIT;
-            for _ in 0..REDIRECT_HOPS {
-                if !matches!(targets, Targets::Masters)
-                    || !replies.iter().any(|r| r.starts_with(b"-READONLY"))
-                {
-                    break;
-                }
-                stats::bump(&shared.wstats.redirect_waits);
-                let _ = shared.refresh.send(());
-                tokio::time::sleep(wait).await;
-                wait *= 2;
-                let topo = shared.topo.load_full();
-                let mut receivers = Vec::with_capacity(topo.masters.len());
-                for &i in &topo.masters {
-                    let addr = &topo.nodes[i as usize].addr;
-                    receivers.push(scatter_one(&shared, addr, lane, None, frame.clone()).await);
-                }
-                replies = collect(receivers).await;
+        let mut replies = collect(receivers).await;
+        if matches!(targets, Targets::Masters) {
+            self.ride_out_demoted(&topo, nodes, &frame, &mut replies)
+                .await;
+        }
+        let merged = match gather {
+            Gather::Sum => multikey::merge_sum(replies.iter(), 0),
+            Gather::Ok => multikey::merge_ok(replies.iter()),
+            Gather::Same => multikey::merge_same(replies.iter()),
+            Gather::Every => multikey::merge_every(replies.iter()),
+        };
+        if let (Ok(reply), Some((body, flushes))) = (&merged, remember)
+            && let Some(sha) = resp::bulk_payload(reply)
+        {
+            shared.scripts.remember(sha, body, flushes);
+        }
+        let _ = self
+            .reply_q
+            .send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
+    }
+
+    // a master demoted since the last refresh answers a keyless write READONLY: after a
+    // refresh its shard's new master gets the request, the replies of the others stand
+    async fn ride_out_demoted(
+        &self,
+        topo: &Topology,
+        nodes: &[u16],
+        frame: &Bytes,
+        replies: &mut [Bytes],
+    ) {
+        let shared = &self.shared;
+        let mut wait = REDIRECT_WAIT;
+        for _ in 0..REDIRECT_HOPS {
+            let demoted: Vec<usize> = (0..replies.len())
+                .filter(|&k| replies[k].starts_with(b"-READONLY"))
+                .collect();
+            if demoted.is_empty() {
+                return;
             }
-            let merged = match gather {
-                Gather::Sum => multikey::merge_sum(replies.iter(), 0),
-                Gather::Ok => multikey::merge_ok(replies.iter()),
-                Gather::Same => multikey::merge_same(replies.iter()),
-                Gather::Every => multikey::merge_every(replies.iter()),
-            };
-            if let (Ok(reply), Some((body, flushes))) = (&merged, remember)
-                && let Some(sha) = resp::bulk_payload(reply)
-            {
-                shared.scripts.remember(sha, body, flushes);
+            stats::bump(&shared.wstats.redirect_waits);
+            let _ = shared.refresh.send(());
+            tokio::time::sleep(wait).await;
+            wait *= 2;
+            let fresh = shared.topo.load_full();
+            for k in demoted {
+                let Some(slot) = topo.slots.iter().position(|&o| o == nodes[k]) else {
+                    continue;
+                };
+                let Some(addr) = fresh.owner_addr(slot as u16) else {
+                    continue;
+                };
+                let rx = scatter_one(shared, addr, self.lane(), None, frame.clone()).await;
+                replies[k] = recv_or_lost(rx).await;
             }
-            let _ = reply_q.send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
-        });
+        }
     }
 }
 

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -4,8 +4,6 @@ use std::rc::Rc;
 
 use bytes::Bytes;
 
-use tokio::sync::oneshot;
-
 use super::pipe::{recv_or_lost, scatter_one};
 use super::session::Session;
 use super::writer::{REDIRECT_HOPS, REDIRECT_WAIT};
@@ -49,8 +47,8 @@ impl Session {
         let link = self.link.clone();
         let topo = shared.topo.load_full();
         let lane = self.lane();
-        let all: Vec<u16> = match targets {
-            Targets::Masters => Vec::new(),
+        let nodes: Vec<u16> = match targets {
+            Targets::Masters => topo.masters.clone(),
             Targets::LiveNodes | Targets::AllNodes => {
                 let live_only = matches!(targets, Targets::LiveNodes);
                 (0..topo.nodes.len() as u16)
@@ -58,12 +56,8 @@ impl Session {
                     .collect()
             }
         };
-        let nodes: &[u16] = match targets {
-            Targets::Masters => &topo.masters,
-            _ => &all,
-        };
         let mut receivers = Vec::with_capacity(nodes.len());
-        for &i in nodes {
+        for &i in &nodes {
             let addr = &topo.nodes[i as usize].addr;
             receivers.push(scatter_one(&shared, addr, lane, None, frame.clone()).await);
         }
@@ -71,9 +65,12 @@ impl Session {
         // detached: the hold keeps later commands of the session behind it while its reader
         // still sees a hang-up, and teardown aborts it like a blocking command
         let task = tokio::task::spawn_local(async move {
-            let mut replies = collect(receivers).await;
+            let mut replies = Vec::with_capacity(receivers.len());
+            for rx in receivers {
+                replies.push(recv_or_lost(rx).await);
+            }
             if matches!(targets, Targets::Masters) {
-                ride_out_demoted(&shared, &topo, &topo.masters, lane, &frame, &mut replies).await;
+                ride_out_demoted(&shared, &topo, lane, &frame, &mut replies).await;
             }
             let merged = match gather {
                 Gather::Sum => multikey::merge_sum(replies.iter(), 0),
@@ -93,12 +90,11 @@ impl Session {
     }
 }
 
-// a leg answered READONLY is a master demoted since the last refresh: after a refresh its
+// a master leg answered READONLY was demoted since the last refresh: after a refresh its
 // shard's new master gets the request; the replies of the other legs stand
 async fn ride_out_demoted(
     shared: &Rc<Shared>,
     topo: &Topology,
-    nodes: &[u16],
     lane: Lane,
     frame: &Bytes,
     replies: &mut [Bytes],
@@ -116,23 +112,21 @@ async fn ride_out_demoted(
         tokio::time::sleep(wait).await;
         wait *= 2;
         let fresh = shared.topo.load_full();
+        let mut pending = Vec::with_capacity(demoted.len());
         for k in demoted {
-            let Some(slot) = topo.slots.iter().position(|&o| o == nodes[k]) else {
+            let Some(slot) = topo.slots.iter().position(|&o| o == topo.masters[k]) else {
                 continue;
             };
             let Some(addr) = fresh.owner_addr(slot as u16) else {
                 continue;
             };
-            let rx = scatter_one(shared, addr, lane, None, frame.clone()).await;
+            pending.push((
+                k,
+                scatter_one(shared, addr, lane, None, frame.clone()).await,
+            ));
+        }
+        for (k, rx) in pending {
             replies[k] = recv_or_lost(rx).await;
         }
     }
-}
-
-async fn collect(receivers: Vec<oneshot::Receiver<Bytes>>) -> Vec<Bytes> {
-    let mut replies = Vec::with_capacity(receivers.len());
-    for rx in receivers {
-        replies.push(recv_or_lost(rx).await);
-    }
-    replies
 }

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -2,11 +2,15 @@
 
 use bytes::Bytes;
 
+use tokio::sync::oneshot;
+
 use super::Reply;
 use super::pipe::{recv_or_lost, scatter_one};
 use super::session::Session;
+use super::writer::{REDIRECT_HOPS, REDIRECT_WAIT};
 use crate::multikey;
 use crate::resp;
+use crate::stats;
 
 /// Which nodes a broadcast reaches.
 #[derive(Clone, Copy)]
@@ -59,9 +63,27 @@ impl Session {
         }
         // detached deliberately: completion is bounded by backend replies
         tokio::task::spawn_local(async move {
-            let mut replies: Vec<Bytes> = Vec::with_capacity(receivers.len());
-            for rx in receivers {
-                replies.push(recv_or_lost(rx).await);
+            let mut replies = collect(receivers).await;
+            // a master demoted since the last refresh answers a keyless write READONLY: ask for
+            // the topology again and send once more to the masters it reports, a few times
+            let mut wait = REDIRECT_WAIT;
+            for _ in 0..REDIRECT_HOPS {
+                if !matches!(targets, Targets::Masters)
+                    || !replies.iter().any(|r| r.starts_with(b"-READONLY"))
+                {
+                    break;
+                }
+                stats::bump(&shared.wstats.redirect_waits);
+                let _ = shared.refresh.send(());
+                tokio::time::sleep(wait).await;
+                wait *= 2;
+                let topo = shared.topo.load_full();
+                let mut receivers = Vec::with_capacity(topo.masters.len());
+                for &i in &topo.masters {
+                    let addr = &topo.nodes[i as usize].addr;
+                    receivers.push(scatter_one(&shared, addr, lane, None, frame.clone()).await);
+                }
+                replies = collect(receivers).await;
             }
             let merged = match gather {
                 Gather::Sum => multikey::merge_sum(replies.iter(), 0),
@@ -77,4 +99,12 @@ impl Session {
             let _ = reply_q.send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
         });
     }
+}
+
+async fn collect(receivers: Vec<oneshot::Receiver<Bytes>>) -> Vec<Bytes> {
+    let mut replies = Vec::with_capacity(receivers.len());
+    for rx in receivers {
+        replies.push(recv_or_lost(rx).await);
+    }
+    replies
 }

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -68,9 +68,9 @@ impl Session {
             receivers.push(scatter_one(&shared, addr, lane, None, frame.clone()).await);
         }
         link.hold.set(true);
-        // detached deliberately: completion is bounded by backend replies; the hold keeps
-        // later commands of the session behind it while its reader still sees a hang-up
-        tokio::task::spawn_local(async move {
+        // detached: the hold keeps later commands of the session behind it while its reader
+        // still sees a hang-up, and teardown aborts it like a blocking command
+        let task = tokio::task::spawn_local(async move {
             let mut replies = collect(receivers).await;
             if matches!(targets, Targets::Masters) {
                 ride_out_demoted(&shared, &topo, &topo.masters, lane, &frame, &mut replies).await;
@@ -89,6 +89,9 @@ impl Session {
             link.hold.set(false);
             let _ = reply_q.send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
         });
+        let mut tasks = self.link.blocking.borrow_mut();
+        tasks.retain(|(_, t)| !t.is_finished());
+        tasks.push((seq, task));
     }
 }
 

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -89,9 +89,7 @@ impl Session {
             link.hold.set(false);
             let _ = reply_q.send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
         });
-        let mut tasks = self.link.blocking.borrow_mut();
-        tasks.retain(|(_, t)| !t.is_finished());
-        tasks.push((seq, task));
+        self.link.track(seq, task);
     }
 }
 

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -1,13 +1,15 @@
 //! Cluster-wide commands: one request to every master or every node, the replies folded into one.
 
+use std::rc::Rc;
+
 use bytes::Bytes;
 
 use tokio::sync::oneshot;
 
-use super::Reply;
 use super::pipe::{recv_or_lost, scatter_one};
 use super::session::Session;
 use super::writer::{REDIRECT_HOPS, REDIRECT_WAIT};
+use super::{Lane, Reply, Shared};
 use crate::multikey;
 use crate::resp;
 use crate::stats;
@@ -33,8 +35,6 @@ pub(super) enum Gather {
 }
 
 impl Session {
-    // the session waits for the replies: a later command of the same client never overtakes
-    // a keyless write, not even one resent after a failover
     pub(super) async fn run_broadcast(
         &self,
         frame: Bytes,
@@ -44,79 +44,86 @@ impl Session {
         remember: Option<(Bytes, u64)>,
     ) {
         let seq = self.alloc_seq();
-        let shared = &self.shared;
+        let shared = self.shared.clone();
+        let reply_q = self.reply_q.clone();
+        let link = self.link.clone();
         let topo = shared.topo.load_full();
         let lane = self.lane();
-        let all;
-        let nodes: &[u16] = match targets {
-            Targets::Masters => &topo.masters,
+        let all: Vec<u16> = match targets {
+            Targets::Masters => Vec::new(),
             Targets::LiveNodes | Targets::AllNodes => {
                 let live_only = matches!(targets, Targets::LiveNodes);
-                all = (0..topo.nodes.len() as u16)
+                (0..topo.nodes.len() as u16)
                     .filter(|&i| !(live_only && topo.nodes[i as usize].fail))
-                    .collect::<Vec<_>>();
-                &all
+                    .collect()
             }
+        };
+        let nodes: &[u16] = match targets {
+            Targets::Masters => &topo.masters,
+            _ => &all,
         };
         let mut receivers = Vec::with_capacity(nodes.len());
         for &i in nodes {
             let addr = &topo.nodes[i as usize].addr;
-            receivers.push(scatter_one(shared, addr, lane, None, frame.clone()).await);
+            receivers.push(scatter_one(&shared, addr, lane, None, frame.clone()).await);
         }
-        let mut replies = collect(receivers).await;
-        if matches!(targets, Targets::Masters) {
-            self.ride_out_demoted(&topo, nodes, &frame, &mut replies)
-                .await;
-        }
-        let merged = match gather {
-            Gather::Sum => multikey::merge_sum(replies.iter(), 0),
-            Gather::Ok => multikey::merge_ok(replies.iter()),
-            Gather::Same => multikey::merge_same(replies.iter()),
-            Gather::Every => multikey::merge_every(replies.iter()),
-        };
-        if let (Ok(reply), Some((body, flushes))) = (&merged, remember)
-            && let Some(sha) = resp::bulk_payload(reply)
-        {
-            shared.scripts.remember(sha, body, flushes);
-        }
-        let _ = self
-            .reply_q
-            .send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
+        link.hold.set(true);
+        // detached deliberately: completion is bounded by backend replies; the hold keeps
+        // later commands of the session behind it while its reader still sees a hang-up
+        tokio::task::spawn_local(async move {
+            let mut replies = collect(receivers).await;
+            if matches!(targets, Targets::Masters) {
+                ride_out_demoted(&shared, &topo, &topo.masters, lane, &frame, &mut replies).await;
+            }
+            let merged = match gather {
+                Gather::Sum => multikey::merge_sum(replies.iter(), 0),
+                Gather::Ok => multikey::merge_ok(replies.iter()),
+                Gather::Same => multikey::merge_same(replies.iter()),
+                Gather::Every => multikey::merge_every(replies.iter()),
+            };
+            if let (Ok(reply), Some((body, flushes))) = (&merged, remember)
+                && let Some(sha) = resp::bulk_payload(reply)
+            {
+                shared.scripts.remember(sha, body, flushes);
+            }
+            link.hold.set(false);
+            let _ = reply_q.send(Reply::At(seq, merged.unwrap_or_else(|e| e)));
+        });
     }
+}
 
-    // a master demoted since the last refresh answers a keyless write READONLY: after a
-    // refresh its shard's new master gets the request, the replies of the others stand
-    async fn ride_out_demoted(
-        &self,
-        topo: &Topology,
-        nodes: &[u16],
-        frame: &Bytes,
-        replies: &mut [Bytes],
-    ) {
-        let shared = &self.shared;
-        let mut wait = REDIRECT_WAIT;
-        for _ in 0..REDIRECT_HOPS {
-            let demoted: Vec<usize> = (0..replies.len())
-                .filter(|&k| replies[k].starts_with(b"-READONLY"))
-                .collect();
-            if demoted.is_empty() {
-                return;
-            }
-            stats::bump(&shared.wstats.redirect_waits);
-            let _ = shared.refresh.send(());
-            tokio::time::sleep(wait).await;
-            wait *= 2;
-            let fresh = shared.topo.load_full();
-            for k in demoted {
-                let Some(slot) = topo.slots.iter().position(|&o| o == nodes[k]) else {
-                    continue;
-                };
-                let Some(addr) = fresh.owner_addr(slot as u16) else {
-                    continue;
-                };
-                let rx = scatter_one(shared, addr, self.lane(), None, frame.clone()).await;
-                replies[k] = recv_or_lost(rx).await;
-            }
+// a leg answered READONLY is a master demoted since the last refresh: after a refresh its
+// shard's new master gets the request; the replies of the other legs stand
+async fn ride_out_demoted(
+    shared: &Rc<Shared>,
+    topo: &Topology,
+    nodes: &[u16],
+    lane: Lane,
+    frame: &Bytes,
+    replies: &mut [Bytes],
+) {
+    let mut wait = REDIRECT_WAIT;
+    for _ in 0..REDIRECT_HOPS {
+        let demoted: Vec<usize> = (0..replies.len())
+            .filter(|&k| replies[k].starts_with(b"-READONLY"))
+            .collect();
+        if demoted.is_empty() {
+            return;
+        }
+        stats::bump(&shared.wstats.redirect_waits);
+        let _ = shared.refresh.send(());
+        tokio::time::sleep(wait).await;
+        wait *= 2;
+        let fresh = shared.topo.load_full();
+        for k in demoted {
+            let Some(slot) = topo.slots.iter().position(|&o| o == nodes[k]) else {
+                continue;
+            };
+            let Some(addr) = fresh.owner_addr(slot as u16) else {
+                continue;
+            };
+            let rx = scatter_one(shared, addr, lane, None, frame.clone()).await;
+            replies[k] = recv_or_lost(rx).await;
         }
     }
 }

--- a/src/client/fanout.rs
+++ b/src/client/fanout.rs
@@ -214,8 +214,8 @@ impl Session {
         let shared = self.shared.clone();
         let reply_q = self.reply_q.clone();
         let lane = self.lane();
-        // detached deliberately: completion is bounded by backend replies
-        tokio::task::spawn_local(async move {
+        // detached: bounded by backend replies, aborted at teardown
+        let task = tokio::task::spawn_local(async move {
             let topo = shared.topo.load_full();
             if master_idx >= topo.masters.len() {
                 let done = multikey::rebuild_scan_reply(0, b"*0\r\n");
@@ -250,6 +250,7 @@ impl Session {
             };
             let _ = reply_q.send(Reply::At(seq, out));
         });
+        self.link.track(seq, task);
     }
 
     async fn fan_out_resume(
@@ -445,8 +446,8 @@ impl Session {
         let reply_q = self.reply_q.clone();
         // the lane is snapshotted here: a later SELECT must not move these parts
         let lane = self.lane();
-        // detached deliberately: completion is bounded by backend replies
-        tokio::task::spawn_local(async move {
+        // detached: bounded by backend replies, aborted at teardown
+        let task = tokio::task::spawn_local(async move {
             let _marks = marks;
             let mut results: Vec<(Vec<usize>, Bytes)> = Vec::with_capacity(parts.len());
             let mut retries: Vec<(multikey::Part, oneshot::Receiver<Bytes>)> = Vec::new();
@@ -508,6 +509,7 @@ impl Session {
             gate.notify_waiters();
             let _ = reply_q.send(Reply::At(seq, singles.merge(total, &results)));
         });
+        self.link.track(seq, task);
     }
 }
 

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -150,6 +150,13 @@ impl WriterLink {
         self.migrating_any.set(!slots.is_empty());
     }
 
+    /// Registers a detached task answering at `seq`, so teardown can abort and backfill it.
+    pub(super) fn track(&self, seq: u64, task: JoinHandle<()>) {
+        let mut tasks = self.blocking.borrow_mut();
+        tasks.retain(|(_, t)| !t.is_finished());
+        tasks.push((seq, task));
+    }
+
     pub(super) fn gate_slots(&self, slots: &[u16], gate: &Rc<Notify>) {
         let mut gates = self.fanouts.borrow_mut();
         for &slot in slots {

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -32,7 +32,6 @@ pub(super) struct InFlight {
 // sequences are allocated monotonically, so the ring stays sorted
 pub(super) type InflightRing = RefCell<VecDeque<InFlight>>;
 
-// a redirect's target and whether it was ASK
 pub(super) type Hop = (bool, Box<str>);
 
 // state shared between a session's reader, writer, and pubsub relay

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -25,12 +25,15 @@ pub(super) struct InFlight {
     pub(super) waited: bool,
     pub(super) fill: Option<Fill>,
     pub(super) db: u8,
-    // where a redirect sent the request, for a reload the topology cannot place yet
-    pub(super) target: Option<Box<str>>,
+    // where a redirect sent the request and whether it was ASK, for a reload there
+    pub(super) target: Option<Hop>,
 }
 
 // sequences are allocated monotonically, so the ring stays sorted
 pub(super) type InflightRing = RefCell<VecDeque<InFlight>>;
+
+// a redirect's target and whether it was ASK
+pub(super) type Hop = (bool, Box<str>);
 
 // state shared between a session's reader, writer, and pubsub relay
 #[derive(Default)]
@@ -41,6 +44,8 @@ pub(super) struct WriterLink {
     pub(super) emitted: Cell<u64>,
     // set when no reply can ever be written again; reader must stop dispatching
     pub(super) closed: Cell<bool>,
+    // a cluster-wide command in flight: the reader keeps reading but dispatches nothing
+    pub(super) hold: Cell<bool>,
     pub(super) closed_notify: Notify,
     pub(super) proto_switches: ProtoSwitchQueue,
     pub(super) oob_budget: Cell<usize>,

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -20,10 +20,13 @@ pub(super) struct InFlight {
     pub(super) frame: Bytes,
     pub(super) expect: u32,
     pub(super) retried: bool,
+    pub(super) reloaded: bool,
     pub(super) degraded: bool,
     pub(super) waited: bool,
     pub(super) fill: Option<Fill>,
     pub(super) db: u8,
+    // where a redirect sent the request, for a reload the topology cannot place yet
+    pub(super) target: Option<Box<str>>,
 }
 
 // sequences are allocated monotonically, so the ring stays sorted

--- a/src/client/pipe.rs
+++ b/src/client/pipe.rs
@@ -143,8 +143,18 @@ pub(super) fn stage_one(
     head: Option<Bytes>,
     frame: Bytes,
 ) -> (Staged, oneshot::Receiver<Bytes>) {
-    let (tx, rx) = oneshot::channel();
     let expect = 1 + u32::from(head.is_some());
+    stage_expect(pipe, head, frame, expect)
+}
+
+// `head` may carry several frames; `expect` counts every reply, and only the last is delivered
+pub(super) fn stage_expect(
+    pipe: &Pipe,
+    head: Option<Bytes>,
+    frame: Bytes,
+    expect: u32,
+) -> (Staged, oneshot::Receiver<Bytes>) {
+    let (tx, rx) = oneshot::channel();
     let staged = match pipe {
         Pipe::Local(conn) => Staged::Local(
             conn.clone(),
@@ -186,6 +196,20 @@ pub(super) async fn scatter_one(
     frame: Bytes,
 ) -> oneshot::Receiver<Bytes> {
     scatter_pipe(&pipe_for(shared, addr, lane, false), head, frame).await
+}
+
+pub(super) async fn scatter_expect(
+    shared: &Rc<Shared>,
+    addr: &str,
+    lane: Lane,
+    head: Bytes,
+    frame: Bytes,
+    expect: u32,
+) -> oneshot::Receiver<Bytes> {
+    let pipe = pipe_for(shared, addr, lane, false);
+    let (staged, rx) = stage_expect(&pipe, Some(head), frame, expect);
+    staged.send().await;
+    rx
 }
 
 pub(super) async fn recv_or_lost(rx: oneshot::Receiver<Bytes>) -> Bytes {

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -525,10 +525,12 @@ impl Session {
             frame: frame.clone(),
             expect,
             retried: false,
+            reloaded: false,
             degraded: false,
             waited: false,
             fill,
             db: self.link.db.get(),
+            target: None,
         });
     }
 

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -621,7 +621,8 @@ impl Session {
 
     fn window_full(&self) -> bool {
         let outstanding = self.outstanding();
-        outstanding >= MAX_INFLIGHT as u64 || (self.switch_pending.get() && outstanding > 0)
+        outstanding >= MAX_INFLIGHT as u64
+            || ((self.switch_pending.get() || self.link.hold.get()) && outstanding > 0)
     }
 }
 

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -10,7 +10,7 @@ use tokio::net::tcp::OwnedWriteHalf;
 use tokio::sync::{Notify, oneshot};
 
 use super::fanout::{Singles, multikey_plan, request_slot, resend_singles, write_keys};
-use super::link::{Fill, InFlight, InflightRing, WriterLink, mark_closed};
+use super::link::{Fill, Hop, InFlight, InflightRing, WriterLink, mark_closed};
 use super::pipe::{parse_redirect, pipe_for, queue_on, recv_or_lost, scatter_one};
 use super::pubsub::PUBSUB_PUSH_WINDOW;
 use super::queue::ReplyQueue;
@@ -250,20 +250,22 @@ pub(super) async fn write_loop(
                         && let Some((retry, db, target)) = take_reload(&link, seq)
                     {
                         let topo = shared.topo.load_full();
-                        let target = match target.as_deref() {
-                            Some(t) => Some(t),
-                            None => evalsha_target(&topo, &retry.0),
+                        let (asked, target) = match &target {
+                            Some((asked, t)) => (*asked, Some(t.as_ref())),
+                            None => (false, evalsha_target(&topo, &retry.0)),
                         };
                         if let (Some(load), Some(target)) =
                             (shared.scripts.load_frame(&retry.0), target)
                         {
+                            let lane = link.lane_with(client_id, db);
+                            let head = reload_head(&shared, target, lane, load, asked).await;
                             let resend = Resend {
                                 shared: &shared,
                                 reply_q: &reply_q,
                                 link: &link,
                                 client_id,
                             };
-                            resend.requeue(target, seq, Some(load), retry, 1, db).await;
+                            resend.requeue(target, seq, Some(head), retry, 1, db).await;
                             continue;
                         }
                     } else if frame.starts_with(b"-TRYAGAIN")
@@ -445,7 +447,7 @@ fn rerunnable(link: &WriterLink, seq: u64) -> bool {
 }
 
 // one script reload per request, at the node a redirect sent it to when one did
-fn take_reload(link: &WriterLink, seq: u64) -> Option<(Retry, u8, Option<Box<str>>)> {
+fn take_reload(link: &WriterLink, seq: u64) -> Option<(Retry, u8, Option<Hop>)> {
     let mut entry = entry_at(&link.inflight, seq)?;
     if entry.reloaded {
         return None;
@@ -464,7 +466,7 @@ fn take_retry(link: &WriterLink, seq: u64, ask: bool, target: &str) -> Option<(R
         return None;
     }
     entry.retried = true;
-    entry.target = Some(Box::from(target));
+    entry.target = Some((ask, Box::from(target)));
     let db = entry.db;
     let fill = link.detach_fill(&mut entry);
     Some(((entry.frame.clone(), entry.expect, fill), db))
@@ -505,9 +507,10 @@ fn ride_out(
         let req = retry.0.clone();
         let (mut reply, last) = follow_slot(&shared, lane, slot, reply, retry).await;
         if reply.starts_with(NOSCRIPT)
-            && let (Some(load), Some(target)) = (shared.scripts.load_frame(&req), last)
+            && let (Some(load), Some((asked, target))) = (shared.scripts.load_frame(&req), last)
         {
-            let rx = scatter_one(&shared, &target, lane, Some(load), req).await;
+            let head = reload_head(&shared, &target, lane, load, asked).await;
+            let rx = scatter_one(&shared, &target, lane, Some(head), req).await;
             reply = recv_or_lost(rx).await;
         }
         if parse_redirect(&reply).is_some() {
@@ -519,16 +522,32 @@ fn ride_out(
     });
 }
 
+// the frame that precedes a rerun after a reload: the script goes ahead on its own when the
+// rerun must carry ASKING, otherwise the load itself leads
+async fn reload_head(
+    shared: &Rc<Shared>,
+    target: &str,
+    lane: Lane,
+    load: Bytes,
+    asked: bool,
+) -> Bytes {
+    if !asked {
+        return load;
+    }
+    drop(scatter_one(shared, target, lane, None, load).await);
+    Bytes::from_static(ASKING_FRAME)
+}
+
 // each hop waits, then goes where the reply points (a redirect's target) or where the slot
 // lives now (TRYAGAIN under an atomic migration); the first real answer stands, with the
-// node that gave it, and an error outlasting the hops is the caller's to judge
+// hop that got it, and an error outlasting the hops is the caller's to judge
 async fn follow_slot(
     shared: &Rc<Shared>,
     lane: Lane,
     slot: u16,
     mut reply: Bytes,
     (req, _, fill): Retry,
-) -> (Bytes, Option<String>) {
+) -> (Bytes, Option<(bool, String)>) {
     if let Some(fill) = fill
         && let Some(cache) = &shared.cache
     {
@@ -551,7 +570,7 @@ async fn follow_slot(
         let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
         let rx = scatter_one(shared, &target, lane, head, req.clone()).await;
         reply = recv_or_lost(rx).await;
-        last = Some(target);
+        last = Some((ask, target));
     }
     (reply, last)
 }

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefMut;
 use std::collections::VecDeque;
+use std::future::Future;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -283,13 +284,9 @@ pub(super) async fn write_loop(
                             link.mark_migrating(slot);
                             // otherwise the client retries and this slot takes the gated path
                             if rerunnable(&link, seq) {
-                                let gate = Rc::new(Notify::new());
-                                link.gate_slots(&[slot], &gate);
-                                let (s, q, l) = (shared.clone(), reply_q.clone(), link.clone());
-                                // detached: bounded by backend replies, aborted at teardown
-                                let task = tokio::task::spawn_local(async move {
-                                    let (shared, reply_q, link) = (s, q, l);
-                                    let lane = link.lane_with(client_id, db);
+                                let shared = shared.clone();
+                                let lane = link.lane_with(client_id, db);
+                                ride(&link, &reply_q, seq, slot, async move {
                                     // an atomic migration hands the slot over whole: ride it out
                                     // first; split only if the keys really sit on two nodes
                                     let (whole, _) = follow_slot(
@@ -327,11 +324,8 @@ pub(super) async fn write_loop(
                                             cache.invalidate(k)
                                         });
                                     }
-                                    link.release_gates(&[slot]);
-                                    gate.notify_waiters();
-                                    let _ = reply_q.send(Reply::At(seq, reply));
+                                    reply
                                 });
-                                link.track(seq, task);
                                 continue;
                             }
                         }
@@ -490,8 +484,8 @@ fn take_bounce(link: &WriterLink, seq: u64) -> Option<(Retry, u16, u8)> {
     Some(((entry.frame.clone(), entry.expect, fill), slot, db))
 }
 
-// gates the slot and rides the change out on a detached task; the answer lands at the
-// request's own sequence, a redirect never
+// rides a topology change out: the request follows the slot, a script it needs is reloaded
+// where it landed, and a redirect never reaches the client
 fn ride_out(
     shared: &Rc<Shared>,
     reply_q: &Rc<ReplyQueue>,
@@ -500,13 +494,9 @@ fn ride_out(
     reply: Bytes,
     retry: Retry,
 ) {
-    let gate = Rc::new(Notify::new());
-    link.gate_slots(&[slot], &gate);
-    let (s, q, l) = (shared.clone(), reply_q.clone(), link.clone());
-    // detached: bounded by the hops and one backend reply each, aborted at teardown
-    let task = tokio::task::spawn_local(async move {
-        let (shared, reply_q, link) = (s, q, l);
-        let lane = link.lane_with(client_id, db);
+    let shared = shared.clone();
+    let lane = link.lane_with(client_id, db);
+    ride(link, reply_q, seq, slot, async move {
         let req = retry.0.clone();
         let (mut reply, last) = follow_slot(&shared, lane, slot, reply, retry).await;
         if reply.starts_with(NOSCRIPT)
@@ -519,10 +509,30 @@ fn ride_out(
         if parse_redirect(&reply).is_some() {
             reply = Bytes::from_static(ERR_TRYAGAIN);
         }
-        link.release_gates(&[slot]);
-        gate.notify_waiters();
-        let _ = reply_q.send(Reply::At(seq, reply));
+        reply
     });
+}
+
+// runs `work` on a detached task gated on `slot`: its answer lands at `seq`, later commands
+// of the slot wait for it, and teardown aborts it like a blocking command
+fn ride(
+    link: &Rc<WriterLink>,
+    reply_q: &Rc<ReplyQueue>,
+    seq: u64,
+    slot: u16,
+    work: impl Future<Output = Bytes> + 'static,
+) {
+    let gate = Rc::new(Notify::new());
+    link.gate_slots(&[slot], &gate);
+    let task = {
+        let (link, reply_q) = (link.clone(), reply_q.clone());
+        tokio::task::spawn_local(async move {
+            let reply = work.await;
+            link.release_gates(&[slot]);
+            gate.notify_waiters();
+            let _ = reply_q.send(Reply::At(seq, reply));
+        })
+    };
     link.track(seq, task);
 }
 
@@ -544,7 +554,7 @@ async fn follow_slot(
     slot: u16,
     mut reply: Bytes,
     (req, _, fill): Retry,
-) -> (Bytes, Option<(bool, String)>) {
+) -> (Bytes, Option<Hop>) {
     if let Some(fill) = fill
         && let Some(cache) = &shared.cache
     {
@@ -553,10 +563,10 @@ async fn follow_slot(
     let mut last = None;
     let mut wait = REDIRECT_WAIT;
     for _ in 0..REDIRECT_HOPS {
-        let (ask, target) = match parse_redirect(&reply) {
-            Some((ask, target)) => (ask, target.to_owned()),
+        let (ask, target): Hop = match parse_redirect(&reply) {
+            Some((ask, target)) => (ask, Box::from(target)),
             None if reply.starts_with(b"-TRYAGAIN") => match shared.topo.load().owner_addr(slot) {
-                Some(addr) => (false, addr.to_owned()),
+                Some(addr) => (false, Box::from(addr)),
                 None => break,
             },
             None => break,

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -28,8 +28,8 @@ type Retry = (Bytes, u32, Option<Fill>);
 
 // an atomic slot migration's handoff leaves the two nodes briefly disagreeing on the owner: a
 // request redirected again waits between its next hops, doubling from here
-const REDIRECT_WAIT: Duration = Duration::from_millis(2);
-const REDIRECT_HOPS: u32 = 6;
+pub(super) const REDIRECT_WAIT: Duration = Duration::from_millis(2);
+pub(super) const REDIRECT_HOPS: u32 = 6;
 
 // out-of-order replies by sequence distance; the back slot is always Some
 #[derive(Default)]
@@ -232,20 +232,14 @@ pub(super) async fn write_loop(
                             continue;
                         }
                         if let Some((retry, slot, db)) = take_bounce(&link, seq) {
-                            stats::bump(&shared.wstats.redirect_waits);
-                            let gate = Rc::new(Notify::new());
-                            link.gate_slots(&[slot], &gate);
-                            let (shared, reply_q, link) =
-                                (shared.clone(), reply_q.clone(), link.clone());
-                            // detached deliberately: bounded by the hops and one backend reply each
-                            tokio::task::spawn_local(async move {
-                                let reply =
-                                    follow(&shared, link.lane_with(client_id, db), frame, retry)
-                                        .await;
-                                link.release_gates(&[slot]);
-                                gate.notify_waiters();
-                                let _ = reply_q.send(Reply::At(seq, reply));
-                            });
+                            ride_out(
+                                &shared,
+                                &reply_q,
+                                &link,
+                                (client_id, seq, slot, db),
+                                frame,
+                                retry,
+                            );
                             continue;
                         }
                         // clients believe the proxy owns every slot: never leak redirects
@@ -290,16 +284,34 @@ pub(super) async fn write_loop(
                                     (shared.clone(), reply_q.clone(), link.clone());
                                 // detached deliberately: completion is bounded by backend replies
                                 tokio::task::spawn_local(async move {
-                                    let mut singles = Singles::new(merge);
-                                    resend_singles(
+                                    let lane = link.lane_with(client_id, db);
+                                    // an atomic migration hands the slot over whole: ride it out
+                                    // first; split only if the keys really sit on two nodes
+                                    let whole = follow_slot(
                                         &shared,
-                                        link.lane_with(client_id, db),
-                                        &req,
-                                        nkeys,
-                                        0..nkeys,
-                                        &mut singles,
+                                        lane,
+                                        slot,
+                                        frame,
+                                        (req.clone(), 1, None),
                                     )
                                     .await;
+                                    let reply = if whole.starts_with(b"-TRYAGAIN")
+                                        || parse_redirect(&whole).is_some()
+                                    {
+                                        let mut singles = Singles::new(merge);
+                                        resend_singles(
+                                            &shared,
+                                            lane,
+                                            &req,
+                                            nkeys,
+                                            0..nkeys,
+                                            &mut singles,
+                                        )
+                                        .await;
+                                        singles.merge(nkeys, &[])
+                                    } else {
+                                        whole
+                                    };
                                     // a fill raced by the late writes goes before the gate lets
                                     // the client read again
                                     if plan.spec.is_write()
@@ -312,7 +324,7 @@ pub(super) async fn write_loop(
                                     }
                                     link.release_gates(&[slot]);
                                     gate.notify_waiters();
-                                    let _ = reply_q.send(Reply::At(seq, singles.merge(nkeys, &[])));
+                                    let _ = reply_q.send(Reply::At(seq, reply));
                                 });
                                 continue;
                             }
@@ -442,7 +454,7 @@ fn take_retry(link: &WriterLink, seq: u64, ask: bool) -> Option<(Retry, u8)> {
     Some(((entry.frame.clone(), entry.expect, fill), db))
 }
 
-// a request redirected a second time waits the handoff out once, while nothing later holds a sequence
+// a request that must wait a topology change out takes one ride, while nothing later holds a sequence
 fn take_bounce(link: &WriterLink, seq: u64) -> Option<(Retry, u16, u8)> {
     if !rerunnable(link, seq) {
         return None;
@@ -458,11 +470,41 @@ fn take_bounce(link: &WriterLink, seq: u64) -> Option<(Retry, u16, u8)> {
     Some(((entry.frame.clone(), entry.expect, fill), slot, db))
 }
 
-// the request follows each redirect after a wait; the last answer stands
-async fn follow(
+// gates the slot and rides the change out on a detached task; the answer lands at the
+// request's own sequence, a redirect never
+fn ride_out(
+    shared: &Rc<Shared>,
+    reply_q: &Rc<ReplyQueue>,
+    link: &Rc<WriterLink>,
+    (client_id, seq, slot, db): (u64, u64, u16, u8),
+    reply: Bytes,
+    retry: Retry,
+) {
+    stats::bump(&shared.wstats.redirect_waits);
+    let gate = Rc::new(Notify::new());
+    link.gate_slots(&[slot], &gate);
+    let (shared, reply_q, link) = (shared.clone(), reply_q.clone(), link.clone());
+    // detached deliberately: bounded by the hops and one backend reply each
+    tokio::task::spawn_local(async move {
+        let lane = link.lane_with(client_id, db);
+        let mut reply = follow_slot(&shared, lane, slot, reply, retry).await;
+        if parse_redirect(&reply).is_some() {
+            reply = Bytes::from_static(ERR_TRYAGAIN);
+        }
+        link.release_gates(&[slot]);
+        gate.notify_waiters();
+        let _ = reply_q.send(Reply::At(seq, reply));
+    });
+}
+
+// each hop waits, then goes where the reply points (a redirect's target) or where the slot
+// lives now (TRYAGAIN under an atomic migration); the first real answer stands, an error
+// outlasting the hops is the caller's to judge
+async fn follow_slot(
     shared: &Rc<Shared>,
     lane: Lane,
-    mut redirect: Bytes,
+    slot: u16,
+    mut reply: Bytes,
     (req, _, fill): Retry,
 ) -> Bytes {
     if let Some(fill) = fill
@@ -472,20 +514,21 @@ async fn follow(
     }
     let mut wait = REDIRECT_WAIT;
     for _ in 0..REDIRECT_HOPS {
-        let Some((ask, target)) = parse_redirect(&redirect) else {
-            return redirect;
+        let (ask, target) = match parse_redirect(&reply) {
+            Some((ask, target)) => (ask, target.to_owned()),
+            None if reply.starts_with(b"-TRYAGAIN") => match shared.topo.load().owner_addr(slot) {
+                Some(addr) => (false, addr.to_owned()),
+                None => return reply,
+            },
+            None => return reply,
         };
         tokio::time::sleep(wait).await;
         wait *= 2;
         let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
-        let rx = scatter_one(shared, target, lane, head, req.clone()).await;
-        redirect = recv_or_lost(rx).await;
+        let rx = scatter_one(shared, &target, lane, head, req.clone()).await;
+        reply = recv_or_lost(rx).await;
     }
-    if parse_redirect(&redirect).is_some() {
-        Bytes::from_static(ERR_TRYAGAIN)
-    } else {
-        redirect
-    }
+    reply
 }
 
 // one key-by-key resend per request, whether or not a redirect retry preceded it

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -285,10 +285,10 @@ pub(super) async fn write_loop(
                             if rerunnable(&link, seq) {
                                 let gate = Rc::new(Notify::new());
                                 link.gate_slots(&[slot], &gate);
-                                let (shared, reply_q, link) =
-                                    (shared.clone(), reply_q.clone(), link.clone());
-                                // detached deliberately: completion is bounded by backend replies
-                                tokio::task::spawn_local(async move {
+                                let (s, q, l) = (shared.clone(), reply_q.clone(), link.clone());
+                                // detached: bounded by backend replies, aborted at teardown
+                                let task = tokio::task::spawn_local(async move {
+                                    let (shared, reply_q, link) = (s, q, l);
                                     let lane = link.lane_with(client_id, db);
                                     // an atomic migration hands the slot over whole: ride it out
                                     // first; split only if the keys really sit on two nodes
@@ -331,6 +331,7 @@ pub(super) async fn write_loop(
                                     gate.notify_waiters();
                                     let _ = reply_q.send(Reply::At(seq, reply));
                                 });
+                                link.track(seq, task);
                                 continue;
                             }
                         }
@@ -501,9 +502,10 @@ fn ride_out(
 ) {
     let gate = Rc::new(Notify::new());
     link.gate_slots(&[slot], &gate);
-    let (shared, reply_q, link) = (shared.clone(), reply_q.clone(), link.clone());
-    // detached deliberately: bounded by the hops and one backend reply each
-    tokio::task::spawn_local(async move {
+    let (s, q, l) = (shared.clone(), reply_q.clone(), link.clone());
+    // detached: bounded by the hops and one backend reply each, aborted at teardown
+    let task = tokio::task::spawn_local(async move {
+        let (shared, reply_q, link) = (s, q, l);
         let lane = link.lane_with(client_id, db);
         let req = retry.0.clone();
         let (mut reply, last) = follow_slot(&shared, lane, slot, reply, retry).await;
@@ -521,6 +523,7 @@ fn ride_out(
         gate.notify_waiters();
         let _ = reply_q.send(Reply::At(seq, reply));
     });
+    link.track(seq, task);
 }
 
 // what a reload sends ahead of the rerun on the same pipe, and how many replies that adds:

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -11,7 +11,7 @@ use tokio::sync::{Notify, oneshot};
 
 use super::fanout::{Singles, multikey_plan, request_slot, resend_singles, write_keys};
 use super::link::{Fill, Hop, InFlight, InflightRing, WriterLink, mark_closed};
-use super::pipe::{parse_redirect, pipe_for, queue_on, recv_or_lost, scatter_one};
+use super::pipe::{parse_redirect, pipe_for, queue_on, recv_or_lost, scatter_expect, scatter_one};
 use super::pubsub::PUBSUB_PUSH_WINDOW;
 use super::queue::ReplyQueue;
 use super::scripting::evalsha_target;
@@ -257,15 +257,16 @@ pub(super) async fn write_loop(
                         if let (Some(load), Some(target)) =
                             (shared.scripts.load_frame(&retry.0), target)
                         {
-                            let lane = link.lane_with(client_id, db);
-                            let head = reload_head(&shared, target, lane, load, asked).await;
+                            let (head, replies) = reload_head(load, asked);
                             let resend = Resend {
                                 shared: &shared,
                                 reply_q: &reply_q,
                                 link: &link,
                                 client_id,
                             };
-                            resend.requeue(target, seq, Some(head), retry, 1, db).await;
+                            resend
+                                .requeue(target, seq, Some(head), retry, replies, db)
+                                .await;
                             continue;
                         }
                     } else if frame.starts_with(b"-TRYAGAIN")
@@ -509,8 +510,8 @@ fn ride_out(
         if reply.starts_with(NOSCRIPT)
             && let (Some(load), Some((asked, target))) = (shared.scripts.load_frame(&req), last)
         {
-            let head = reload_head(&shared, &target, lane, load, asked).await;
-            let rx = scatter_one(&shared, &target, lane, Some(head), req).await;
+            let (head, replies) = reload_head(load, asked);
+            let rx = scatter_expect(&shared, &target, lane, head, req, 1 + replies).await;
             reply = recv_or_lost(rx).await;
         }
         if parse_redirect(&reply).is_some() {
@@ -522,20 +523,13 @@ fn ride_out(
     });
 }
 
-// the frame that precedes a rerun after a reload: the script goes ahead on its own when the
-// rerun must carry ASKING, otherwise the load itself leads
-async fn reload_head(
-    shared: &Rc<Shared>,
-    target: &str,
-    lane: Lane,
-    load: Bytes,
-    asked: bool,
-) -> Bytes {
+// what a reload sends ahead of the rerun on the same pipe, and how many replies that adds:
+// the script, then ASKING when the rerun must carry it
+fn reload_head(load: Bytes, asked: bool) -> (Bytes, u32) {
     if !asked {
-        return load;
+        return (load, 1);
     }
-    drop(scatter_one(shared, target, lane, None, load).await);
-    Bytes::from_static(ASKING_FRAME)
+    (Bytes::from([load.as_ref(), ASKING_FRAME].concat()), 2)
 }
 
 // each hop waits, then goes where the reply points (a redirect's target) or where the slot

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -216,7 +216,7 @@ pub(super) async fn write_loop(
                 }
                 if frame.first() == Some(&b'-') {
                     if let Some((ask, target)) = parse_redirect(&frame) {
-                        if let Some((retry, db)) = take_retry(&link, seq, ask) {
+                        if let Some((retry, db)) = take_retry(&link, seq, ask, target) {
                             stats::bump(&shared.wstats.redirects);
                             let _ = shared.refresh.send(());
                             let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
@@ -247,14 +247,16 @@ pub(super) async fn write_loop(
                         frame = Bytes::from_static(ERR_TRYAGAIN);
                     } else if frame.starts_with(NOSCRIPT)
                         && rerunnable(&link, seq)
-                        && let Some((retry, db)) = take_retry(&link, seq, false)
+                        && let Some((retry, db, target)) = take_reload(&link, seq)
                     {
                         let topo = shared.topo.load_full();
-                        let reload = shared
-                            .scripts
-                            .load_frame(&retry.0)
-                            .and_then(|load| Some((load, evalsha_target(&topo, &retry.0)?)));
-                        if let Some((load, target)) = reload {
+                        let target = match target.as_deref() {
+                            Some(t) => Some(t),
+                            None => evalsha_target(&topo, &retry.0),
+                        };
+                        if let (Some(load), Some(target)) =
+                            (shared.scripts.load_frame(&retry.0), target)
+                        {
                             let resend = Resend {
                                 shared: &shared,
                                 reply_q: &reply_q,
@@ -287,7 +289,7 @@ pub(super) async fn write_loop(
                                     let lane = link.lane_with(client_id, db);
                                     // an atomic migration hands the slot over whole: ride it out
                                     // first; split only if the keys really sit on two nodes
-                                    let whole = follow_slot(
+                                    let (whole, _) = follow_slot(
                                         &shared,
                                         lane,
                                         slot,
@@ -295,9 +297,7 @@ pub(super) async fn write_loop(
                                         (req.clone(), 1, None),
                                     )
                                     .await;
-                                    let reply = if whole.starts_with(b"-TRYAGAIN")
-                                        || parse_redirect(&whole).is_some()
-                                    {
+                                    let reply = if whole.starts_with(b"-TRYAGAIN") {
                                         let mut singles = Singles::new(merge);
                                         resend_singles(
                                             &shared,
@@ -309,6 +309,8 @@ pub(super) async fn write_loop(
                                         )
                                         .await;
                                         singles.merge(nkeys, &[])
+                                    } else if parse_redirect(&whole).is_some() {
+                                        Bytes::from_static(ERR_TRYAGAIN)
                                     } else {
                                         whole
                                     };
@@ -442,13 +444,27 @@ fn rerunnable(link: &WriterLink, seq: u64) -> bool {
     seq + 1 == link.next_seq.get()
 }
 
+// one script reload per request, at the node a redirect sent it to when one did
+fn take_reload(link: &WriterLink, seq: u64) -> Option<(Retry, u8, Option<Box<str>>)> {
+    let mut entry = entry_at(&link.inflight, seq)?;
+    if entry.reloaded {
+        return None;
+    }
+    entry.reloaded = true;
+    let db = entry.db;
+    let fill = link.detach_fill(&mut entry);
+    let target = entry.target.take();
+    Some(((entry.frame.clone(), entry.expect, fill), db, target))
+}
+
 // retryable redirects: single-reply requests always, multi-reply blobs only for MOVED
-fn take_retry(link: &WriterLink, seq: u64, ask: bool) -> Option<(Retry, u8)> {
+fn take_retry(link: &WriterLink, seq: u64, ask: bool, target: &str) -> Option<(Retry, u8)> {
     let mut entry = entry_at(&link.inflight, seq)?;
     if entry.retried || (entry.expect > 1 && ask) {
         return None;
     }
     entry.retried = true;
+    entry.target = Some(Box::from(target));
     let db = entry.db;
     let fill = link.detach_fill(&mut entry);
     Some(((entry.frame.clone(), entry.expect, fill), db))
@@ -480,14 +496,20 @@ fn ride_out(
     reply: Bytes,
     retry: Retry,
 ) {
-    stats::bump(&shared.wstats.redirect_waits);
     let gate = Rc::new(Notify::new());
     link.gate_slots(&[slot], &gate);
     let (shared, reply_q, link) = (shared.clone(), reply_q.clone(), link.clone());
     // detached deliberately: bounded by the hops and one backend reply each
     tokio::task::spawn_local(async move {
         let lane = link.lane_with(client_id, db);
-        let mut reply = follow_slot(&shared, lane, slot, reply, retry).await;
+        let req = retry.0.clone();
+        let (mut reply, last) = follow_slot(&shared, lane, slot, reply, retry).await;
+        if reply.starts_with(NOSCRIPT)
+            && let (Some(load), Some(target)) = (shared.scripts.load_frame(&req), last)
+        {
+            let rx = scatter_one(&shared, &target, lane, Some(load), req).await;
+            reply = recv_or_lost(rx).await;
+        }
         if parse_redirect(&reply).is_some() {
             reply = Bytes::from_static(ERR_TRYAGAIN);
         }
@@ -498,37 +520,40 @@ fn ride_out(
 }
 
 // each hop waits, then goes where the reply points (a redirect's target) or where the slot
-// lives now (TRYAGAIN under an atomic migration); the first real answer stands, an error
-// outlasting the hops is the caller's to judge
+// lives now (TRYAGAIN under an atomic migration); the first real answer stands, with the
+// node that gave it, and an error outlasting the hops is the caller's to judge
 async fn follow_slot(
     shared: &Rc<Shared>,
     lane: Lane,
     slot: u16,
     mut reply: Bytes,
     (req, _, fill): Retry,
-) -> Bytes {
+) -> (Bytes, Option<String>) {
     if let Some(fill) = fill
         && let Some(cache) = &shared.cache
     {
         fill.abandon(cache);
     }
+    let mut last = None;
     let mut wait = REDIRECT_WAIT;
     for _ in 0..REDIRECT_HOPS {
         let (ask, target) = match parse_redirect(&reply) {
             Some((ask, target)) => (ask, target.to_owned()),
             None if reply.starts_with(b"-TRYAGAIN") => match shared.topo.load().owner_addr(slot) {
                 Some(addr) => (false, addr.to_owned()),
-                None => return reply,
+                None => break,
             },
-            None => return reply,
+            None => break,
         };
+        stats::bump(&shared.wstats.redirect_waits);
         tokio::time::sleep(wait).await;
         wait *= 2;
         let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
         let rx = scatter_one(shared, &target, lane, head, req.clone()).await;
         reply = recv_or_lost(rx).await;
+        last = Some(target);
     }
-    reply
+    (reply, last)
 }
 
 // one key-by-key resend per request, whether or not a redirect retry preceded it


### PR DESCRIPTION
Hardens the three ride-outs the docs listed as boundaries, and closes two holes the new tests found.

- A same-slot multi-key command refused mid-migration (`TRYAGAIN`) is first retried whole with short waits (2 ms doubling, up to six), so under an atomic slot migration a same-slot MSET/DEL stays atomic; only a refusal that outlasts the waits (a legacy migration with the keys really split) falls back to the key-by-key resend. A redirect that outlasts the waits answers `TRYAGAIN`, never a split.
- A keyless write broadcast (FLUSHALL, FUNCTION LOAD, SCRIPT FLUSH, ...) that a demoted master answers `READONLY` after a failover is resent, after a topology refresh, to the new master of that shard only; the other masters' replies stand, so a FUNCTION LOAD is never repeated where it already took. The session's later commands wait behind the broadcast (`WriterLink.hold`, treated by `window_full` like a pending pipe switch) while its reader keeps reading, so a client that hangs up during a stalled broadcast is still freed.
- An EVALSHA answered `NOSCRIPT` after a redirect is reloaded at the node the redirect named (the in-flight entry remembers the hop and its ASK bit), before the pending topology refresh could place it; after ASK the reload sends SCRIPT LOAD and ASKING ahead of the rerun as one outbound.
- Every detached answerer (blocking command, broadcast, both ride-outs) is registered through `WriterLink::track`, so teardown aborts it and backfills its sequence.

Tests: `test_mset_stays_atomic_under_slot_migration` (writer and watcher threads across four atomic migrations), `test_keyless_write_rides_out_a_failover` (FUNCTION LOAD churn through `CLUSTER FAILOVER TAKEOVER` and back; fails on master with 20 ReadOnlyError), `test_evalsha_reloads_after_a_redirect` (fails on master with NoScriptError); the reply-cache MGET probe waits through the post-failover re-arm window. Docs: behavior, commands, compatibility, operations.

Hot path: one `Option<(bool, Box<str>)>` and one `bool` per in-flight entry, written empty; one Cell load in `window_full` per request.

Gates: unit 96; the 15-cell compatibility matrix (redis 6.2/7.4/8.2/8.10, valkey 9.1 × nocache/cache/autocache) green; ct1 IT ×8 green, functional suite 159 / 162 passed (the remaining failures are the documented mt-proxy-only surface). Review converged (round 136).
