### PR TITLE
perf: the slow log is opt-in

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ See [`mithril.conf.sample`](https://github.com/projecteru2/mithril/blob/master/m
 | `user` | line | none | an ACL user, repeatable: `user <name> <rules...>` in Redis ACL SETUSER syntax (`user app on >secret ~app:* &* -@all +@read +@string`); applied at startup, editable afterwards with ACL SETUSER |
 | `acl-pubsub-default` | enum | `allchannels` | channels a new or `reset` user starts with: `allchannels` or `resetchannels`; changeable at runtime via `CONFIG SET` |
 | `acllog-max-len` | 0..1000000 | `128` | entries kept by ACL LOG; changeable at runtime via `CONFIG SET` |
-| `slowlog-log-slower-than` | µs, -1 off | `10000` | a command whose reply took at least this long, from being read to being queued for the client, enters the slow log; `0` keeps every command; changeable at runtime via `CONFIG SET` |
+| `slowlog-log-slower-than` | µs, -1 off | `-1` | off by default; set to a microsecond threshold and a command whose reply took at least this long, from being read to being queued for the client, enters the slow log (`0` keeps every command; Redis defaults to `10000`); changeable at runtime via `CONFIG SET` |
 | `slowlog-max-len` | 0..1000000 | `128` | entries the slow log keeps, newest first; changeable at runtime via `CONFIG SET` |
 | `backend-auth-user` | string | empty | username sent to backends (`AUTH user pass`) |
 | `backend-auth-pass` | string | empty | password sent to backends |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -38,8 +38,10 @@ moment its reply was queued for the client (the backend round trip included)
 is kept, newest `slowlog-max-len` entries, and `SLOWLOG GET [count]`,
 `SLOWLOG LEN` and `SLOWLOG RESET` read it in the Redis format (id, unix time,
 microseconds, up to 32 arguments of up to 128 bytes, client address, client
-name). The default threshold is 10 ms as in Redis; `-1` switches timing
-off, `0` keeps every command. Every accepted command is timed from the
+name). The log is off by default (`-1`): timing every command costs a clock
+read and a queue entry per command, measured at about 1% of peak throughput,
+so it is switched on when needed, at runtime or in the config file; `10000`
+is Redis's 10 ms, `0` keeps every command. Every accepted command is timed from the
 moment it is read to the moment its first reply is queued for the client:
 routed, fanned out, cluster-wide, run through a WATCH, answered by the
 proxy or served from the reply cache alike; only a blocking command, whose

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,11 +41,11 @@ microseconds, up to 32 arguments of up to 128 bytes, client address, client
 name). The log is off by default (`-1`): timing every command costs a clock
 read and a queue entry per command, measured at about 1% of peak throughput,
 so it is switched on when needed, at runtime or in the config file; `10000`
-is Redis's 10 ms, `0` keeps every command. Every accepted command is timed from the
-moment it is read to the moment its first reply is queued for the client:
-routed, fanned out, cluster-wide, run through a WATCH, answered by the
-proxy or served from the reply cache alike; only a blocking command, whose
-wait is the client's own, is left out. A transaction is one
+is Redis's 10 ms, `0` keeps every command. While it is on, every accepted
+command is timed from the moment it is read to the moment its first reply
+is queued for the client: routed, fanned out, cluster-wide, run through a
+WATCH, answered by the proxy or served from the reply cache alike; only a
+blocking command, whose wait is the client's own, is left out. A transaction is one
 entry named `exec`; the arguments of AUTH and HELLO, the rules of ACL SETUSER
 and the password values of a CONFIG SET read `(redacted)`.
 SLOWLOG answers once the session's earlier replies have settled into the

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -1364,7 +1364,7 @@ def test_slowlog_keeps_commands_over_the_threshold(r, new_conn, key_prefix):
         assert r.slowlog_len() == 0
         assert r.config_get("slowlog-log-slower-than") == {"slowlog-log-slower-than": "-1"}
     finally:
-        r.config_set("slowlog-log-slower-than", 10000)
+        r.config_set("slowlog-log-slower-than", -1)
         r.config_set("slowlog-max-len", 128)
         r.delete(k)
 

--- a/mithril.conf.sample
+++ b/mithril.conf.sample
@@ -30,7 +30,7 @@ backend-conns 1
 # user app on >secret ~app:* &* -@all +@read +@string
 # acl-pubsub-default allchannels
 # acllog-max-len 128
-# slowlog-log-slower-than 10000
+# slowlog-log-slower-than -1
 # slowlog-max-len 128
 # backend-auth-user default
 # backend-auth-pass secret

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,7 +127,7 @@ impl Default for Config {
             query_buffer_limit: 1024 * 1024 * 1024,
             topology_refresh_secs: 15,
             loglevel: crate::log::NOTICE,
-            slowlog_log_slower_than: 10_000,
+            slowlog_log_slower_than: -1,
             slowlog_max_len: 128,
         }
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -128,7 +128,7 @@ impl Slowlog {
 impl Default for Slowlog {
     fn default() -> Slowlog {
         Slowlog {
-            slower_than: AtomicI64::new(10_000),
+            slower_than: AtomicI64::new(-1),
             max_len: AtomicUsize::new(128),
             ring: Mutex::new((VecDeque::new(), 0)),
         }


### PR DESCRIPTION
The slow log is now opt-in: `slowlog-log-slower-than` defaults to `-1`; `CONFIG SET` or the config file turns it on (Redis's 10 ms is `10000`).

Measured on the 128-master rig (64 workers, default mode, P16 c1000, 8 rounds, arm order rotated per round; four arms: master before the batch, master after it, the same binary with the log off, and a byte-identical A/A copy): with the log on at 10 ms every command pays a clock read and a queue entry, a consistent −1.3% on SET at peak (sem 0.14, 0/8 rounds up) and −0.8% on GET (inside the A/A floor); with it off the binary sits within −0.6…−0.75% of the pre-batch master, which is the next micro-pass. Fastest in every case is the product rule; parity with Redis stays one config line away.

Docs: configuration.md (default and rationale), operations.md (the timing paragraph now reads conditionally, a docs-only follow-up commit), mithril.conf.sample.

Gates: unit 104; the 15-cell compatibility matrix green; ct1 IT ×8 green, functional suite 165 / 165 passed. Review converged.
