### PR TITLE
review: one fence wait, one timing cell, one epoch clock

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,7 +18,7 @@ client's current command in `cmd`.
 | Stats | `total_connections_received`, `total_commands_processed`, `total_net_input_bytes`, `total_net_output_bytes`, `total_error_replies`, `redirections`, `redirect_waits`, session lifecycle counters (`readers_exited`, `writers_exited`, `sessions_closed`) |
 | Mithril | `worker_threads`, `backend_conns_per_node`, `backend_sharding`, `slave_mode`, `reply_cache`, `cache_hits`, `cache_misses`, `cache_invalidations`, `cache_entries`, `cache_bytes`, `cache_flips`, `cache_armed_workers`, `worker_commands` (per-worker) |
 | Cluster | `cluster_enabled` (always 1) |
-| Commandstats | `cmdstat_<command>:calls=<n>` for every command run at least once, subcommands as `cmdstat_client\|list`; counted once accepted (known, well-formed, permitted), summed over workers |
+| Commandstats | `cmdstat_<command>:calls=<n>` for every command run at least once, subcommands as `cmdstat_client\|list`; counted once accepted, summed over workers |
 
 `CLIENT LIST` lists every connection across workers (id, addr, fd, name,
 age).
@@ -42,9 +42,8 @@ name). The log is off by default (`-1`): timing every command costs a clock
 read and a queue entry per command, measured at about 1% of peak throughput,
 so it is switched on when needed, at runtime or in the config file; `10000`
 is Redis's 10 ms, `0` keeps every command. While it is on, every accepted
-command is timed from the moment it is read to the moment its first reply
-is queued for the client: routed, fanned out, cluster-wide, run through a
-WATCH, answered by the proxy or served from the reply cache alike; only a
+command is timed, whether routed, fanned out, cluster-wide, run through a
+WATCH, answered by the proxy or served from the reply cache; only a
 blocking command, whose wait is the client's own, is left out. A transaction is one
 entry named `exec`; the arguments of AUTH and HELLO, the rules of ACL SETUSER
 and the password values of a CONFIG SET read `(redacted)`.

--- a/it/test_proxy.py
+++ b/it/test_proxy.py
@@ -1323,8 +1323,7 @@ def test_info_counts_commands_and_client_list_names_the_last(r, new_conn, key_pr
 
 
 def test_slowlog_keeps_commands_over_the_threshold(r, new_conn, key_prefix):
-    k, other = f"{key_prefix}:slow", f"{key_prefix}:slow2"
-    assert key_slot(other.encode()) != key_slot(k.encode())
+    k, other = _cross_slot_pair(key_prefix)
     assert r.config_set("slowlog-log-slower-than", 0)
     assert r.config_set("slowlog-max-len", 4096)
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -196,10 +196,7 @@ pub fn cluster(args: &[&[u8]], cfg: &Config, proto: u8) -> Vec<u8> {
 
 pub fn info(cfg: &Config, stats: &Stats, started: u64) -> Vec<u8> {
     let (cpu_sys, cpu_user) = cpu_seconds();
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let now = stats::unix_secs();
     let mut text = format!(
         "# Server\r\nredis_version:{SERVER_VERSION}\r\nredis_mode:cluster\r\n\
          mithril_version:{}\r\nprocess_id:{}\r\ntcp_port:{}\r\nuptime_in_seconds:{}\r\n\
@@ -431,9 +428,13 @@ fn config_set(acl: &Acl, stats: &Stats, key: &[u8], value: &[u8]) -> Result<(), 
         let v = crate::config::parse_slower_than(&value).map_err(|e| format!("ERR {e}"))?;
         stats.slowlog.slower_than.store(v, Ordering::Relaxed);
     } else if key.eq_ignore_ascii_case(b"slowlog-max-len") {
-        let v = value.parse::<usize>().ok().filter(|v| *v <= 1_000_000).ok_or_else(|| {
-            "ERR CONFIG SET failed (possibly related to argument 'slowlog-max-len') - argument must be between 0 and 1000000 inclusive".to_string()
-        })?;
+        let v = value
+            .parse::<usize>()
+            .ok()
+            .filter(|v| *v <= stats::SLOWLOG_MAX_LEN_LIMIT)
+            .ok_or_else(|| {
+                format!("ERR CONFIG SET failed (possibly related to argument 'slowlog-max-len') - argument must be between 0 and {} inclusive", stats::SLOWLOG_MAX_LEN_LIMIT)
+            })?;
         stats.slowlog.max_len.store(v, Ordering::Relaxed);
     } else if key.eq_ignore_ascii_case(b"loglevel") {
         crate::log::set_level(crate::log::parse_level(&value).map_err(|e| format!("ERR {e}"))?);

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -11,7 +11,6 @@ use tokio::task::JoinHandle;
 
 use super::Lane;
 use super::pubsub::{PendingSub, PubsubSim};
-use super::watch::settled;
 use super::watch::{NO_WATCH, Watched};
 use crate::cache::ReplyCache;
 use crate::multikey;
@@ -48,8 +47,8 @@ pub(super) struct WriterLink {
     pub(super) hold: Cell<bool>,
     // (sequence, microsecond read, request) of each timed command, in sequence order
     pub(super) timings: RefCell<VecDeque<(u64, u64, Bytes)>>,
-    // timed commands not yet settled; the writer's sweep skips the queue at zero
-    pub(super) timings_pending: Cell<usize>,
+    // a timed command is not yet settled; the writer's sweep skips the queue otherwise
+    pub(super) timings_pending: Cell<bool>,
     pub(super) closed_notify: Notify,
     pub(super) proto_switches: ProtoSwitchQueue,
     pub(super) oob_budget: Cell<usize>,
@@ -262,6 +261,19 @@ type FanoutGates = HashMap<u16, Rc<Notify>, BuildHasherDefault<multikey::SlotHas
 pub(super) fn mark_closed(link: &WriterLink) {
     link.closed.set(true);
     link.closed_notify.notify_one();
+}
+
+// a wait that cannot miss the notification between the check and the sleep
+async fn settled(notify: &Notify, pending: impl Fn() -> bool) {
+    loop {
+        let notified = notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if !pending() {
+            return;
+        }
+        notified.await;
+    }
 }
 
 #[cfg(test)]

--- a/src/client/link.rs
+++ b/src/client/link.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 
 use super::Lane;
 use super::pubsub::{PendingSub, PubsubSim};
+use super::watch::settled;
 use super::watch::{NO_WATCH, Watched};
 use crate::cache::ReplyCache;
 use crate::multikey;
@@ -47,6 +48,8 @@ pub(super) struct WriterLink {
     pub(super) hold: Cell<bool>,
     // (sequence, microsecond read, request) of each timed command, in sequence order
     pub(super) timings: RefCell<VecDeque<(u64, u64, Bytes)>>,
+    // timed commands not yet settled; the writer's sweep skips the queue at zero
+    pub(super) timings_pending: Cell<usize>,
     pub(super) closed_notify: Notify,
     pub(super) proto_switches: ProtoSwitchQueue,
     pub(super) oob_budget: Cell<usize>,
@@ -149,6 +152,13 @@ impl WriterLink {
         let mut slots = self.migrating.borrow_mut();
         slots.retain(|&s| keep(s));
         self.migrating_any.set(!slots.is_empty());
+    }
+
+    /// Waits until the writer has emitted every reply before `seq`.
+    pub(super) async fn fence_wait(&self, seq: u64) {
+        self.fence_waiters.set(self.fence_waiters.get() + 1);
+        settled(&self.fence_notify, || self.emitted.get() < seq).await;
+        self.fence_waiters.set(self.fence_waiters.get() - 1);
     }
 
     /// Registers a detached task answering at `seq`, so teardown can abort and backfill it.

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -47,7 +47,7 @@ pub(super) struct Session {
     pub(super) id: u64,
     cmd: Arc<AtomicU16>,
     // the accepted command's stamp and request while the slow log is on, until a sequence takes them
-    pub(super) timed: Cell<Option<(u64, Bytes)>>,
+    timed: Cell<Option<(u64, Bytes)>>,
     pub(super) reply_q: Rc<ReplyQueue>,
     pub(super) link: Rc<WriterLink>,
     pub(super) proto: Cell<u8>,
@@ -272,9 +272,7 @@ impl Session {
                 .timings
                 .borrow_mut()
                 .push_back((seq, started_us, frame));
-            self.link
-                .timings_pending
-                .set(self.link.timings_pending.get() + 1);
+            self.link.timings_pending.set(true);
         }
         seq
     }

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -23,7 +23,7 @@ use super::pipe::{ColdSend, Pipe, pipe_for, queue_on};
 use super::pubsub::{PubsubHandle, pubsub_allowed, settles_first};
 use super::queue::ReplyQueue;
 use super::tuner::PIPELINED_LOCAL;
-use super::watch::{NO_WATCH, settled};
+use super::watch::NO_WATCH;
 use super::writer::write_loop;
 use super::{
     Cold, ERR_CROSSSLOT, ERR_NO_OWNER, ERR_NOAUTH, Lane, MAX_INFLIGHT, Reply, Shared, error_frame,
@@ -46,9 +46,8 @@ pub(super) struct Session {
     pub(super) shared: Rc<Shared>,
     pub(super) id: u64,
     cmd: Arc<AtomicU16>,
-    started_us: Cell<u64>,
-    // the accepted command's request while the slow log is on, until its sequence is allocated
-    pub(super) timed: Cell<Option<Bytes>>,
+    // the accepted command's stamp and request while the slow log is on, until a sequence takes them
+    pub(super) timed: Cell<Option<(u64, Bytes)>>,
     pub(super) reply_q: Rc<ReplyQueue>,
     pub(super) link: Rc<WriterLink>,
     pub(super) proto: Cell<u8>,
@@ -253,9 +252,7 @@ impl Session {
             (self.shared.clone(), self.reply_q.clone(), self.link.clone());
         link.hold.set(true);
         let task = tokio::task::spawn_local(async move {
-            link.fence_waiters.set(link.fence_waiters.get() + 1);
-            settled(&link.fence_notify, || link.emitted.get() < seq).await;
-            link.fence_waiters.set(link.fence_waiters.get() - 1);
+            link.fence_wait(seq).await;
             let args: Vec<&[u8]> = resp::Args::new(&frame, argc).collect();
             let reply = admin::slowlog_cmd(&args, &shared.stats);
             link.hold.set(false);
@@ -270,11 +267,14 @@ impl Session {
         if !self.link.writer_blocked.get() {
             self.shared.inflight.set(self.shared.inflight.get() + 1);
         }
-        if let Some(frame) = self.timed.take() {
+        if let Some((started_us, frame)) = self.timed.take() {
             self.link
                 .timings
                 .borrow_mut()
-                .push_back((seq, self.started_us.get(), frame));
+                .push_back((seq, started_us, frame));
+            self.link
+                .timings_pending
+                .set(self.link.timings_pending.get() + 1);
         }
         seq
     }
@@ -302,12 +302,8 @@ impl Session {
             self.closing.set(true);
             return;
         }
-        self.started_us
-            .set(if self.shared.stats.slowlog.threshold() >= 0 {
-                self.shared.stats.micros()
-            } else {
-                0
-            });
+        let started_us =
+            (self.shared.stats.slowlog.threshold() >= 0).then(|| self.shared.stats.micros());
         if argc == 0 {
             return;
         }
@@ -365,9 +361,10 @@ impl Session {
         let queued = self.in_multi.get() && spec.flags & command::FLAG_TXN_CTRL == 0;
         let xread =
             (spec.kind == Kind::Xread).then(|| xread_slot(&frame, argc, spec.scan_from as usize));
-        let blocks = spec.kind == Kind::Blocking || matches!(xread, Some(Some((_, true))));
-        self.timed
-            .set((self.started_us.get() != 0 && !blocks && !queued).then(|| frame.clone()));
+        self.timed.set(started_us.and_then(|us| {
+            let blocks = spec.kind == Kind::Blocking || matches!(xread, Some(Some((_, true))));
+            (!blocks && !queued).then(|| (us, frame.clone()))
+        }));
         if self.auto {
             self.adapt_pipes();
         }
@@ -390,7 +387,7 @@ impl Session {
                 return;
             }
         }
-        if self.in_multi.get() && spec.flags & command::FLAG_TXN_CTRL == 0 {
+        if queued {
             self.queue_multi(spec, frame, argc);
             return;
         }
@@ -498,7 +495,7 @@ impl Session {
             }
             Kind::Nodes => {
                 let mut args: Vec<&[u8]> = resp::Args::new(&frame, argc).collect();
-                args[0] = &spec.name.as_bytes()[1..];
+                args[0] = spec.name.strip_prefix('p').unwrap_or(spec.name).as_bytes();
                 let mut plain = Vec::with_capacity(frame.len());
                 resp::write_command(&mut plain, &args);
                 if Box::pin(self.gates_clear()).await {
@@ -757,7 +754,6 @@ pub async fn serve(shared: Rc<Shared>, stream: TcpStream, addr: SocketAddr, id: 
         shared: shared.clone(),
         id,
         cmd: listed.cmd.clone(),
-        started_us: Cell::new(0),
         timed: Cell::new(None),
         reply_q: reply_q.clone(),
         link: link.clone(),

--- a/src/client/watch.rs
+++ b/src/client/watch.rs
@@ -523,9 +523,7 @@ async fn arm(
     (seq, frame): (u64, Bytes),
     (addr, db): (String, u8),
 ) {
-    link.fence_waiters.set(link.fence_waiters.get() + 1);
-    settled(&link.fence_notify, || link.emitted.get() < seq).await;
-    link.fence_waiters.set(link.fence_waiters.get() - 1);
+    link.fence_wait(seq).await;
     let Some(lease) = shared.backends.take_exclusive(&addr, db) else {
         watched.lose(link, reply_q, seq, error_frame(ERR_EXCLUSIVE_LIMIT));
         return;

--- a/src/client/watch.rs
+++ b/src/client/watch.rs
@@ -10,7 +10,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 
 use bytes::Bytes;
-use tokio::sync::{Notify, oneshot};
+use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 
 use super::fanout::write_keys;
@@ -593,19 +593,6 @@ async fn unwatched(watched: &Watched, sent: Option<(oneshot::Receiver<Bytes>, u6
     };
     recv_or_lost(rx).await;
     watched.accepted.get() > mark
-}
-
-// a wait that cannot miss the notification between the check and the sleep
-pub(super) async fn settled(notify: &Notify, pending: impl Fn() -> bool) {
-    loop {
-        let notified = notify.notified();
-        tokio::pin!(notified);
-        notified.as_mut().enable();
-        if !pending() {
-            return;
-        }
-        notified.await;
-    }
 }
 
 async fn deliver_exec(

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -333,15 +333,13 @@ pub(super) async fn write_loop(
                             }
                         }
                     }
+                    stats::bump(&shared.wstats.errors);
                 }
                 if link.fills_armed.get() > 0
                     && let Some(fill) = take_fill(&link, seq)
                     && let Some(cache) = &shared.cache
                 {
                     fill.complete(cache, &frame);
-                }
-                if frame.first() == Some(&b'-') {
-                    stats::bump(&shared.wstats.errors);
                 }
                 if seq == next_emit {
                     link.proto_switches.apply(next_emit, &mut cur_proto);
@@ -396,14 +394,17 @@ pub(super) async fn write_loop(
                 }
             }
             drop(inf);
-            let mut timings = link.timings.borrow_mut();
-            while timings.front().is_some_and(|t| t.0 < next_emit) {
-                if let Some((_, started_us, frame)) = timings.pop_front() {
-                    shared.stats.log_slow(client_id, started_us, frame);
+            if link.timings_pending.get() > 0 {
+                let mut timings = link.timings.borrow_mut();
+                while timings.front().is_some_and(|t| t.0 < next_emit) {
+                    if let Some((_, started_us, frame)) = timings.pop_front() {
+                        link.timings_pending.set(link.timings_pending.get() - 1);
+                        shared.stats.log_slow(client_id, started_us, frame);
+                    }
                 }
-            }
-            if timings.is_empty() && timings.capacity() > 256 {
-                *timings = VecDeque::new();
+                if timings.is_empty() && timings.capacity() > 256 {
+                    *timings = VecDeque::new();
+                }
             }
             swept_to = next_emit;
         }

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -394,16 +394,18 @@ pub(super) async fn write_loop(
                 }
             }
             drop(inf);
-            if link.timings_pending.get() > 0 {
+            if link.timings_pending.get() {
                 let mut timings = link.timings.borrow_mut();
                 while timings.front().is_some_and(|t| t.0 < next_emit) {
                     if let Some((_, started_us, frame)) = timings.pop_front() {
-                        link.timings_pending.set(link.timings_pending.get() - 1);
                         shared.stats.log_slow(client_id, started_us, frame);
                     }
                 }
-                if timings.is_empty() && timings.capacity() > 256 {
-                    *timings = VecDeque::new();
+                if timings.is_empty() {
+                    link.timings_pending.set(false);
+                    if timings.capacity() > 256 {
+                        *timings = VecDeque::new();
+                    }
                 }
             }
             swept_to = next_emit;

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -78,7 +78,8 @@ pub enum Kind {
     Exec,
     /// SCRIPT and FUNCTION management: broadcast, or answered by one master.
     Script,
-    /// Forwarded to every node as the plain command, the replies listed per node.
+    /// A `p`-prefixed command forwarded to every node as the command it names, the replies
+    /// listed per node.
     Nodes,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -127,8 +127,8 @@ impl Default for Config {
             query_buffer_limit: 1024 * 1024 * 1024,
             topology_refresh_secs: 15,
             loglevel: crate::log::NOTICE,
-            slowlog_log_slower_than: -1,
-            slowlog_max_len: 128,
+            slowlog_log_slower_than: crate::stats::SLOWLOG_OFF,
+            slowlog_max_len: crate::stats::SLOWLOG_MAX_LEN,
         }
     }
 }
@@ -194,7 +194,10 @@ impl Config {
             }
             "loglevel" => self.loglevel = crate::log::parse_level(value)?,
             "slowlog-log-slower-than" => self.slowlog_log_slower_than = parse_slower_than(value)?,
-            "slowlog-max-len" => self.slowlog_max_len = parse_bounded(key, value, 0, 1_000_000)?,
+            "slowlog-max-len" => {
+                self.slowlog_max_len =
+                    parse_bounded(key, value, 0, crate::stats::SLOWLOG_MAX_LEN_LIMIT)?;
+            }
             _ => return Err(format!("unknown parameter '{key}'")),
         }
         Ok(())

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,7 +5,7 @@ use std::net::SocketAddr;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use bytes::BytesMut;
@@ -17,7 +17,7 @@ use crate::backend::Backends;
 use crate::client::{Shared, auto_tuner, serve};
 use crate::config::{Config, Placement, Sharding};
 use crate::shard;
-use crate::stats::Stats;
+use crate::stats::{self, Stats};
 use crate::topology::Topology;
 use crate::{log_notice, log_warn, resp};
 
@@ -159,10 +159,7 @@ pub fn run(cfg: Config) -> Result<(), String> {
         .slowlog
         .max_len
         .store(cfg.slowlog_max_len, Ordering::Relaxed);
-    let started = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs();
+    let started = stats::unix_secs();
 
     let boot_rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -18,6 +18,11 @@ pub const NO_COMMAND: u16 = u16::MAX;
 
 /// Newest entries SLOWLOG GET returns without a count.
 pub const SLOWLOG_GET_DEFAULT: usize = 10;
+/// The slow log's defaults: off, and Redis's ring size once on.
+pub const SLOWLOG_OFF: i64 = -1;
+pub const SLOWLOG_MAX_LEN: usize = 128;
+/// Upper bound of `slowlog-max-len`, as in Redis.
+pub const SLOWLOG_MAX_LEN_LIMIT: usize = 1_000_000;
 /// Arguments a slow-log entry keeps; the rest is one summary, as in Redis.
 const SLOWLOG_ARGC_MAX: usize = 32;
 /// Bytes of one argument a slow-log entry keeps; the rest is summarized, as in Redis.
@@ -128,8 +133,8 @@ impl Slowlog {
 impl Default for Slowlog {
     fn default() -> Slowlog {
         Slowlog {
-            slower_than: AtomicI64::new(-1),
-            max_len: AtomicUsize::new(128),
+            slower_than: AtomicI64::new(SLOWLOG_OFF),
+            max_len: AtomicUsize::new(SLOWLOG_MAX_LEN),
             ring: Mutex::new((VecDeque::new(), 0)),
         }
     }
@@ -176,13 +181,9 @@ impl Stats {
             Some(c) => (Box::from(c.addr.to_string()), c.name.clone()),
             None => (Box::from(""), Box::from("")),
         };
-        let at = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
         self.slowlog.record(SlowEntry {
             id: 0,
-            at,
+            at: unix_secs(),
             micros,
             args: Bytes::from(slow_args(&frame)),
             addr,
@@ -196,6 +197,14 @@ impl Stats {
             .map(|w| field(w).load(Ordering::Relaxed))
             .sum()
     }
+}
+
+/// Seconds since the Unix epoch.
+pub fn unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }
 
 /// Bumps a single-writer counter.

--- a/tools/gen-command-table.py
+++ b/tools/gen-command-table.py
@@ -163,6 +163,7 @@ def main():
         table.append((key, f'"{name}", {r["arity"]}, {" | ".join(m) or "0"}, {first}, {last}, {step}, {numkeys}, {scan_from(name, keys)}, Kind::{kind}, {info}, {cats}),'))
     # proxy-only commands the servers do not report: (name, arity, categories)
     for name, arity, cats in [("pslowlog", -2, "A_ADMIN | A_SLOW | A_DANGEROUS")]:
+        assert KIND[name] != "Nodes" or (name[0] == "p" and name[1:] in {r.split('"')[1] for _, r in table}), name
         key = (prefix64(name), len(name), name.encode()[8:])
         table.append((key, f'"{name}", {arity}, 0, 0, 0, 0, 0, 0, Kind::{KIND[name]}, 0, {cats}),'))
     table.sort()


### PR DESCRIPTION
The batch-end cleanup pass over the three landed slow-log and stats PRs (#16, #17, #18): no behavior change.

- One `WriterLink::fence_wait` serves WATCH's arm and SLOWLOG instead of two copies of the fence bookkeeping.
- The command's read stamp and request travel in one cell; the blocking and queued tests, and the frame clone, run only while the slow log is on.
- The writer counts an error reply inside the branch that already inspected the first byte, and skips the timing queue while nothing is pending.
- The slow log's defaults and its length bound are named once and shared by the config parser, the runtime setter and the ring; one epoch-seconds helper replaces three copies.
- The generator asserts the `p`-prefix convention behind `Kind::Nodes`; the slow-log test reuses the cross-slot key helper; two doc sentences say their thing once.

Gates: unit 104; the generated table reproduces; the 15-cell compatibility matrix green; ct1 IT ×8 green, functional suite 165 / 165 passed. Review converged.
