### PR TITLE
review: the loc-justify cuts of the slow-log batch

### DIFF
--- a/src/client/pipe.rs
+++ b/src/client/pipe.rs
@@ -198,20 +198,6 @@ pub(super) async fn scatter_one(
     scatter_pipe(&pipe_for(shared, addr, lane, false), head, frame).await
 }
 
-pub(super) async fn scatter_expect(
-    shared: &Rc<Shared>,
-    addr: &str,
-    lane: Lane,
-    head: Bytes,
-    frame: Bytes,
-    expect: u32,
-) -> oneshot::Receiver<Bytes> {
-    let pipe = pipe_for(shared, addr, lane, false);
-    let (staged, rx) = stage_expect(&pipe, Some(head), frame, expect);
-    staged.send().await;
-    rx
-}
-
 pub(super) async fn recv_or_lost(rx: oneshot::Receiver<Bytes>) -> Bytes {
     rx.await
         .unwrap_or_else(|_| Bytes::from_static(ERR_BACKEND_LOST))

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -261,6 +261,12 @@ impl Session {
         self.link.track(seq, task);
     }
 
+    async fn broadcast_gated(&self, frame: Bytes, targets: Targets, gather: Gather) {
+        if Box::pin(self.gates_clear()).await {
+            Box::pin(self.run_broadcast(frame, targets, gather, None)).await;
+        }
+    }
+
     pub(super) fn alloc_seq(&self) -> u64 {
         let seq = self.link.next_seq.get();
         self.link.next_seq.set(seq + 1);
@@ -472,9 +478,8 @@ impl Session {
                 }
             }
             Kind::Dbsize => {
-                if Box::pin(self.gates_clear()).await {
-                    Box::pin(self.run_broadcast(frame, Targets::Masters, Gather::Sum, None)).await;
-                }
+                self.broadcast_gated(frame, Targets::Masters, Gather::Sum)
+                    .await
             }
             Kind::Flushall => {
                 if let Some(w) = self.link.watch.borrow().as_ref()
@@ -482,9 +487,8 @@ impl Session {
                 {
                     w.mark_dirty();
                 }
-                if Box::pin(self.gates_clear()).await {
-                    Box::pin(self.run_broadcast(frame, Targets::Masters, Gather::Ok, None)).await;
-                }
+                self.broadcast_gated(frame, Targets::Masters, Gather::Ok)
+                    .await;
             }
             Kind::Script => {
                 if Box::pin(self.gates_clear()).await {
@@ -496,15 +500,8 @@ impl Session {
                 args[0] = spec.name.strip_prefix('p').unwrap_or(spec.name).as_bytes();
                 let mut plain = Vec::with_capacity(frame.len());
                 resp::write_command(&mut plain, &args);
-                if Box::pin(self.gates_clear()).await {
-                    Box::pin(self.run_broadcast(
-                        Bytes::from(plain),
-                        Targets::AllNodes,
-                        Gather::PerNode,
-                        None,
-                    ))
+                self.broadcast_gated(Bytes::from(plain), Targets::AllNodes, Gather::PerNode)
                     .await;
-                }
             }
         }
     }

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -12,7 +12,7 @@ use tokio::sync::{Notify, oneshot};
 
 use super::fanout::{Singles, multikey_plan, request_slot, resend_singles, write_keys};
 use super::link::{Fill, Hop, InFlight, InflightRing, WriterLink, mark_closed};
-use super::pipe::{parse_redirect, pipe_for, queue_on, recv_or_lost, scatter_expect, scatter_one};
+use super::pipe::{parse_redirect, pipe_for, queue_on, recv_or_lost, scatter_one, stage_expect};
 use super::pubsub::PUBSUB_PUSH_WINDOW;
 use super::queue::ReplyQueue;
 use super::scripting::evalsha_target;
@@ -522,7 +522,9 @@ fn ride_out(
             && let (Some(load), Some((asked, target))) = (shared.scripts.load_frame(&req), last)
         {
             let (head, replies) = reload_head(load, asked);
-            let rx = scatter_expect(&shared, &target, lane, head, req, 1 + replies).await;
+            let pipe = pipe_for(&shared, &target, lane, false);
+            let (staged, rx) = stage_expect(&pipe, Some(head), req, 1 + replies);
+            staged.send().await;
             reply = recv_or_lost(rx).await;
         }
         if parse_redirect(&reply).is_some() {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -120,9 +120,8 @@ impl Slowlog {
         entry.id = ring.1;
         ring.1 += 1;
         ring.0.push_back(entry);
-        while ring.0.len() > max {
-            ring.0.pop_front();
-        }
+        let excess = ring.0.len().saturating_sub(max);
+        ring.0.drain(..excess);
     }
 
     fn ring(&self) -> MutexGuard<'_, (VecDeque<SlowEntry>, u64)> {
@@ -217,20 +216,15 @@ pub fn add(counter: &AtomicU64, n: u64) {
     counter.store(counter.load(Ordering::Relaxed) + n, Ordering::Relaxed);
 }
 
-// the entry keeps at most 32 arguments of 128 bytes, credentials replaced, and a MULTI blob
-// as the EXEC it stands for
+// the entry keeps at most 32 arguments of 128 bytes, credentials replaced
 fn slow_args(frame: &[u8]) -> Vec<u8> {
     let mut cur = crate::resp::Cursor::default();
-    let (len, argc) = match crate::resp::scan_request_at(frame, &mut cur) {
-        crate::resp::ReqScan::Complete { len, argc } => (len, argc),
-        _ => (frame.len(), 0),
+    let argc = match crate::resp::scan_request_at(frame, &mut cur) {
+        crate::resp::ReqScan::Complete { argc, .. } => argc,
+        _ => 0,
     };
     let args: Vec<&[u8]> = crate::resp::Args::new(frame, argc).collect();
     let mut out = Vec::new();
-    if len < frame.len() && args.len() == 1 && args[0].eq_ignore_ascii_case(b"multi") {
-        crate::resp::write_command(&mut out, &[b"exec"]);
-        return out;
-    }
     let shown = args.len().min(SLOWLOG_ARGC_MAX);
     crate::resp::array_header(&mut out, shown);
     for (i, arg) in args.iter().take(shown).enumerate() {
@@ -309,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn slow_args_clip_redact_and_name_a_transaction() {
+    fn slow_args_clip_and_redact() {
         let text = |args: &[&str]| String::from_utf8_lossy(&slow_args(&frame(args))).into_owned();
         let long = "x".repeat(SLOWLOG_ARG_MAX + 5);
         assert!(text(&["set", "k", &long]).ends_with("... (5 more bytes)\r\n"));
@@ -343,13 +337,6 @@ mod tests {
         let t = text(&rules);
         assert!(t.ends_with("... (12 more arguments)\r\n"), "{t}");
         assert_eq!(t.matches("(redacted)").count(), 28, "{t}");
-        let mut blob = frame(&["multi"]).to_vec();
-        blob.extend_from_slice(&frame(&["set", "k", "v"]));
-        blob.extend_from_slice(&frame(&["exec"]));
-        assert_eq!(
-            String::from_utf8_lossy(&slow_args(&blob)),
-            "*1\r\n$4\r\nexec\r\n"
-        );
     }
 
     #[test]


### PR DESCRIPTION
The cut-list of a production-code mass audit over the slow-log batch (#15–#19), applied as one behavior-preserving commit: net −28 lines.

- `scatter_expect` had one caller, the script reload after a followed redirect; that path now stages and sends inline.
- DBSIZE, FLUSHALL and the node-addressed PSLOWLOG share one gated-broadcast helper instead of three copies of the same wrapper.
- The slow log's MULTI-blob branch was unreachable: EXEC allocates its sequence and takes its own frame for timing before the transaction blob exists, so the entry was already named `exec` by the frame itself. The unit assertion that fed a blob production never produces is removed.
- The slow-log ring trims with one `drain`.

Gates: unit 104; the 15-cell compatibility matrix green; ct1 IT ×8 green, functional suite 165 / 165 passed. Review converged.
