### PR TITLE
fix: a refused caching opt-in re-tracks the connection and reruns the request

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,7 +160,10 @@ tracking connection per master and learns its client id; every shared
 backend connection on that worker enables `CLIENT TRACKING ON REDIRECT <id>
 OPTIN`, and a fill-armed GET is preceded by `CLIENT CACHING YES`, so a server
 tracks exactly the keys this proxy cached and sends one invalidation when
-such a key changes. Writes through the proxy invalidate their keys
+such a key changes. A server that refuses the opt-in, because that
+connection's tracking is off, gets the tracking frame again on it and the
+request runs once more without the opt-in, so the client sees its reply and
+nothing fills. Writes through the proxy invalidate their keys
 synchronously at dispatch (including STORE destinations, script keys and
 queued transaction keys), so a session always reads its own writes. A fill
 that races an invalidation is poisoned rather than cached; a key carries at

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,9 +161,11 @@ backend connection on that worker enables `CLIENT TRACKING ON REDIRECT <id>
 OPTIN`, and a fill-armed GET is preceded by `CLIENT CACHING YES`, so a server
 tracks exactly the keys this proxy cached and sends one invalidation when
 such a key changes. A server that refuses the opt-in, because that
-connection's tracking is off, gets the tracking frame again on it and the
-request runs once more without the opt-in, so the client sees its reply and
-nothing fills. Writes through the proxy invalidate their keys
+connection's tracking is off, gets the tracking frame again on it, and the
+request runs once more without the opt-in — a fan-out part always, a
+single request while it is the session's last in flight, since a rerun
+behind later commands would reorder them — so the client sees its reply
+and nothing fills. Writes through the proxy invalidate their keys
 synchronously at dispatch (including STORE destinations, script keys and
 queued transaction keys), so a session always reads its own writes. A fill
 that races an invalidation is poisoned rather than cached; a key carries at

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -371,8 +371,7 @@ pub fn ensure_read_room(buf: &mut BytesMut) {
     }
 }
 
-// assumes RESP2 backends: a reply with no request pending is a desync, not a push;
-// true once a caching opt-in was refused, which says the connection's tracking is off
+// RESP2 only: a reply with no request pending is a desync, not a push; true on a refused opt-in
 pub(crate) fn pair_replies<S>(
     buf: &mut BytesMut,
     cur: &mut resp::Cursor,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -175,6 +175,7 @@ impl Backends {
             .await;
             check_rearm(rx.await.ok())?;
         }
+        log_debug!("rearm {addr}: {} connections", conns.len());
         Ok(())
     }
 
@@ -270,6 +271,11 @@ impl Backends {
             Some(t) if role == Role::Master && db == 0 => t.borrow().get(addr).cloned(),
             _ => None,
         };
+        log_debug!(
+            "dial {addr} db{db} exclusive={} tracking={}",
+            role == Role::Exclusive,
+            tracking.is_some()
+        );
         let addr = addr.to_string();
         let cfg = self.cfg.clone();
         let depth = self.depth.clone();

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -374,7 +374,6 @@ pub fn ensure_read_room(buf: &mut BytesMut) {
 // assumes RESP2 backends: a reply with no request pending is a desync, not a push;
 // true once a caching opt-in was refused, which says the connection's tracking is off
 pub(crate) fn pair_replies<S>(
-    addr: &str,
     buf: &mut BytesMut,
     cur: &mut resp::Cursor,
     pending: &mut VecDeque<Pending<S>>,
@@ -391,12 +390,7 @@ pub(crate) fn pair_replies<S>(
                     Some(front) if front.expect > 1 => {
                         front.expect -= 1;
                         if front_err.is_none() && frame.first() == Some(&b'-') {
-                            if frame.starts_with(CACHING_REFUSED) {
-                                log_warn!(
-                                    "backend {addr}: caching opt-in refused, tracking re-sent"
-                                );
-                                refused = true;
-                            }
+                            refused |= frame.starts_with(CACHING_REFUSED);
                             *front_err = Some(frame);
                         }
                     }
@@ -495,13 +489,13 @@ pub(crate) async fn pump<S, D: Fn(S, Bytes) + Copy>(
                 if matches!(r, Ok(0) | Err(_)) {
                     break 'io;
                 }
-                match pair_replies(addr, &mut buf, &mut cur, &mut pending, &mut front_err, deliver) {
+                match pair_replies(&mut buf, &mut cur, &mut pending, &mut front_err, deliver) {
                     Err(e) => {
                         log_debug!("backend {addr} protocol error: {e}");
                         break 'io;
                     }
-                    Ok(true) => {
-                        if let Some(frame) = tracking_frame(tracking, addr, db, readonly) {
+                    Ok(true) => match tracking_frame(tracking, addr, db, readonly) {
+                        Some(frame) => {
                             pending.push_back(Pending {
                                 expect: 1,
                                 sink: None,
@@ -509,8 +503,10 @@ pub(crate) async fn pump<S, D: Fn(S, Bytes) + Copy>(
                             if write_frames(&mut write_half, &[frame]).await.is_err() {
                                 break 'io;
                             }
+                            log_warn!("backend {addr}: caching opt-in refused, tracking re-sent");
                         }
-                    }
+                        None => log_warn!("backend {addr}: caching opt-in refused, no tracker up"),
+                    },
                     Ok(false) => {}
                 }
             }
@@ -757,7 +753,7 @@ mod tests {
         let mut cur = resp::Cursor::default();
         let mut front_err = None;
         let got = RefCell::new(Vec::new());
-        pair_replies("m", &mut buf, &mut cur, pending, &mut front_err, |s, f| {
+        pair_replies(&mut buf, &mut cur, pending, &mut front_err, |s, f| {
             got.borrow_mut().push((s, f))
         })?;
         Ok(got.into_inner())
@@ -767,7 +763,7 @@ mod tests {
         let mut buf = BytesMut::from(buf);
         let mut cur = resp::Cursor::default();
         let mut front_err = None;
-        pair_replies("m", &mut buf, &mut cur, pending, &mut front_err, |_, _| {}).unwrap()
+        pair_replies(&mut buf, &mut cur, pending, &mut front_err, |_, _| {}).unwrap()
     }
 
     #[test]

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,11 +14,11 @@ use tokio::net::TcpStream;
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::sync::{mpsc, oneshot};
 
-use crate::cache::TrackingFrames;
+use crate::cache::{CACHING_REFUSED, TrackingFrames};
 use crate::client::{Reply, ReplyQueue};
 use crate::config::{Config, Sharding};
-use crate::log_debug;
 use crate::resp;
+use crate::{log_debug, log_warn};
 
 pub const OUTBOUND_QUEUE: usize = 8192;
 pub const READ_CHUNK: usize = 64 * 1024;
@@ -267,20 +267,23 @@ impl Backends {
             abort: tokio::sync::Notify::new(),
         });
         let task_conn = conn.clone();
-        let tracking = match &self.tracking {
-            Some(t) if role == Role::Master && db == 0 => t.borrow().get(addr).cloned(),
-            _ => None,
-        };
-        log_debug!(
-            "dial {addr} db{db} exclusive={} tracking={}",
-            role == Role::Exclusive,
-            tracking.is_some()
-        );
+        let tracking = (role == Role::Master)
+            .then(|| self.tracking.clone())
+            .flatten();
         let addr = addr.to_string();
         let cfg = self.cfg.clone();
         let depth = self.depth.clone();
         tokio::task::spawn_local(async move {
-            run_conn((&addr, db), rx, role, tracking, &cfg, &task_conn, &depth).await;
+            run_conn(
+                (&addr, db),
+                rx,
+                role,
+                tracking.as_ref(),
+                &cfg,
+                &task_conn,
+                &depth,
+            )
+            .await;
             task_conn.dead.set(true);
         });
         conn
@@ -321,7 +324,8 @@ impl Drop for ExclusiveLease {
 
 pub(crate) struct Pending<S> {
     pub(crate) expect: u32,
-    pub(crate) sink: S,
+    // None for a frame the connection sent on its own account
+    pub(crate) sink: Option<S>,
 }
 
 type PoolPair = [Option<Rc<Pool>>; 2];
@@ -367,14 +371,17 @@ pub fn ensure_read_room(buf: &mut BytesMut) {
     }
 }
 
-// assumes RESP2 backends: a reply with no request pending is a desync, not a push
+// assumes RESP2 backends: a reply with no request pending is a desync, not a push;
+// true once a caching opt-in was refused, which says the connection's tracking is off
 pub(crate) fn pair_replies<S>(
+    addr: &str,
     buf: &mut BytesMut,
     cur: &mut resp::Cursor,
     pending: &mut VecDeque<Pending<S>>,
     front_err: &mut Option<Bytes>,
     deliver: impl Fn(S, Bytes),
-) -> Result<(), &'static str> {
+) -> Result<bool, &'static str> {
+    let mut refused = false;
     loop {
         match resp::scan_value_at(buf, cur) {
             resp::Scan::Complete(len) => {
@@ -384,19 +391,27 @@ pub(crate) fn pair_replies<S>(
                     Some(front) if front.expect > 1 => {
                         front.expect -= 1;
                         if front_err.is_none() && frame.first() == Some(&b'-') {
+                            if frame.starts_with(CACHING_REFUSED) {
+                                log_warn!(
+                                    "backend {addr}: caching opt-in refused, tracking re-sent"
+                                );
+                                refused = true;
+                            }
                             *front_err = Some(frame);
                         }
                     }
                     Some(_) => {
-                        if let Some(d) = pending.pop_front() {
+                        if let Some(d) = pending.pop_front()
+                            && let Some(sink) = d.sink
+                        {
                             // a failed head frame is the reply: the request never ran as sent
-                            deliver(d.sink, front_err.take().unwrap_or(frame));
+                            deliver(sink, front_err.take().unwrap_or(frame));
                         }
                     }
                 }
             }
             resp::Scan::Invalid(e) => return Err(e),
-            resp::Scan::Incomplete => return Ok(()),
+            resp::Scan::Incomplete => return Ok(refused),
         }
     }
 }
@@ -407,24 +422,42 @@ pub(crate) async fn open(
     db: u8,
     readonly: bool,
     cfg: &Config,
-    tracking: Option<&[u8]>,
+    tracking: Option<&TrackingFrames>,
 ) -> Result<(OwnedReadHalf, OwnedWriteHalf), String> {
     let stream = connect(addr, cfg.tcp_keepalive_secs)
         .await
         .map_err(|e| e.to_string())?;
     let (mut r, mut w) = stream.into_split();
-    handshake(&mut r, &mut w, (db, readonly), cfg, tracking).await?;
+    let frame = tracking_frame(tracking, addr, db, readonly);
+    log_debug!(
+        "dial {addr} db{db} readonly={readonly} tracking={}",
+        frame.is_some()
+    );
+    handshake(&mut r, &mut w, (db, readonly), cfg, frame.as_deref()).await?;
     Ok((r, w))
+}
+
+// only a master connection on database 0 carries tracking
+fn tracking_frame(
+    tracking: Option<&TrackingFrames>,
+    addr: &str,
+    db: u8,
+    readonly: bool,
+) -> Option<Bytes> {
+    match tracking {
+        Some(t) if !readonly && db == 0 => t.borrow().get(addr).cloned(),
+        _ => None,
+    }
 }
 
 /// Drives one connection: batches requests into writev, pairs replies to sinks,
 /// and fails what is left once the socket or the abort ends it.
 pub(crate) async fn pump<S, D: Fn(S, Bytes) + Copy>(
-    addr: &str,
+    (addr, db, readonly): (&str, u8, bool),
     rx: &mut mpsc::Receiver<Outbound<S>>,
     (mut read_half, mut write_half): (OwnedReadHalf, OwnedWriteHalf),
-    abort: Option<&tokio::sync::Notify>,
-    depth: Option<&BatchDepth>,
+    (abort, depth): (Option<&tokio::sync::Notify>, Option<&BatchDepth>),
+    tracking: Option<&TrackingFrames>,
     deliver: D,
 ) {
     let mut pending: VecDeque<Pending<S>> = VecDeque::new();
@@ -462,15 +495,29 @@ pub(crate) async fn pump<S, D: Fn(S, Bytes) + Copy>(
                 if matches!(r, Ok(0) | Err(_)) {
                     break 'io;
                 }
-                if let Err(e) = pair_replies(&mut buf, &mut cur, &mut pending, &mut front_err, deliver) {
-                    log_debug!("backend {addr} protocol error: {e}");
-                    break 'io;
+                match pair_replies(addr, &mut buf, &mut cur, &mut pending, &mut front_err, deliver) {
+                    Err(e) => {
+                        log_debug!("backend {addr} protocol error: {e}");
+                        break 'io;
+                    }
+                    Ok(true) => {
+                        if let Some(frame) = tracking_frame(tracking, addr, db, readonly) {
+                            pending.push_back(Pending {
+                                expect: 1,
+                                sink: None,
+                            });
+                            if write_frames(&mut write_half, &[frame]).await.is_err() {
+                                break 'io;
+                            }
+                        }
+                    }
+                    Ok(false) => {}
                 }
             }
         }
     }
-    for p in pending.drain(..) {
-        deliver(p.sink, Bytes::from_static(ERR_BACKEND_LOST));
+    for sink in pending.drain(..).filter_map(|p| p.sink) {
+        deliver(sink, Bytes::from_static(ERR_BACKEND_LOST));
     }
     drain_channel(rx, deliver);
 }
@@ -493,7 +540,7 @@ pub(crate) fn stage<S>(
     for out in batch.drain(..) {
         pending.push_back(Pending {
             expect: out.expect,
-            sink: out.sink,
+            sink: Some(out.sink),
         });
         if let Some(h) = out.head {
             frames.push(h);
@@ -594,7 +641,7 @@ pub(crate) async fn run_pipe<S, D: Fn(S, Bytes) + Copy>(
     (addr, db): (&str, u8),
     readonly: bool,
     cfg: &Config,
-    tracking: Option<&[u8]>,
+    tracking: Option<&TrackingFrames>,
     rx: &mut mpsc::Receiver<Outbound<S>>,
     (abort, depth): (Option<&tokio::sync::Notify>, Option<&BatchDepth>),
     deliver: D,
@@ -604,7 +651,17 @@ pub(crate) async fn run_pipe<S, D: Fn(S, Bytes) + Copy>(
         r = open(addr, db, readonly, cfg, tracking) => r,
     };
     match halves {
-        Ok(halves) => pump(addr, rx, halves, abort, depth, deliver).await,
+        Ok(halves) => {
+            pump(
+                (addr, db, readonly),
+                rx,
+                halves,
+                (abort, depth),
+                tracking,
+                deliver,
+            )
+            .await
+        }
         Err(e) => {
             log_debug!("connect {addr}: {e}");
             drain_channel(rx, deliver);
@@ -632,7 +689,7 @@ async fn run_conn(
     (addr, db): (&str, u8),
     mut rx: mpsc::Receiver<Outbound>,
     role: Role,
-    tracking: Option<Bytes>,
+    tracking: Option<&TrackingFrames>,
     cfg: &Config,
     conn: &Conn,
     depth: &BatchDepth,
@@ -644,7 +701,7 @@ async fn run_conn(
         (addr, db),
         role == Role::Replica,
         cfg,
-        tracking.as_deref(),
+        tracking,
         &mut rx,
         (abort, depth),
         deliver,
@@ -686,7 +743,10 @@ mod tests {
     }
 
     fn pending(expect: u32, tag: u32) -> Pending<u32> {
-        Pending { expect, sink: tag }
+        Pending {
+            expect,
+            sink: Some(tag),
+        }
     }
 
     fn pair(
@@ -697,10 +757,36 @@ mod tests {
         let mut cur = resp::Cursor::default();
         let mut front_err = None;
         let got = RefCell::new(Vec::new());
-        pair_replies(&mut buf, &mut cur, pending, &mut front_err, |s, f| {
+        pair_replies("m", &mut buf, &mut cur, pending, &mut front_err, |s, f| {
             got.borrow_mut().push((s, f))
         })?;
         Ok(got.into_inner())
+    }
+
+    fn refused(buf: &[u8], pending: &mut VecDeque<Pending<u32>>) -> bool {
+        let mut buf = BytesMut::from(buf);
+        let mut cur = resp::Cursor::default();
+        let mut front_err = None;
+        pair_replies("m", &mut buf, &mut cur, pending, &mut front_err, |_, _| {}).unwrap()
+    }
+
+    #[test]
+    fn a_refused_opt_in_is_reported_and_a_sinkless_frame_swallows_its_reply() {
+        let mut queue = VecDeque::from([pending(2, 7)]);
+        assert!(refused(
+            b"-ERR CLIENT CACHING can be called only when tracking\r\n$1\r\nv\r\n",
+            &mut queue
+        ));
+        assert!(!refused(b"+OK\r\n", &mut VecDeque::from([pending(1, 7)])));
+        let mut queue = VecDeque::from([
+            Pending {
+                expect: 1,
+                sink: None,
+            },
+            pending(1, 8),
+        ]);
+        let got = pair(b"+OK\r\n:1\r\n", &mut queue).unwrap();
+        assert_eq!(got, vec![(8, Bytes::from_static(b":1\r\n"))]);
     }
 
     #[test]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -723,6 +723,7 @@ async fn track_once(addr: &str, w: &Rc<Wiring>) -> Result<(), String> {
     };
     w.rearm(addr, &frame).await?;
     w.cache.tracker_up(addr);
+    log_debug!("tracker {addr} up, id {id}");
 
     let mut ping = tokio::time::interval(TRACKER_PING);
     ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -26,6 +26,8 @@ use crate::topology::Topology;
 
 /// Marks the next command on a tracking connection as cached.
 pub const CACHING_FRAME: &[u8] = b"*3\r\n$6\r\nCLIENT\r\n$7\r\nCACHING\r\n$3\r\nYES\r\n";
+/// How a backend whose tracking is off answers that mark.
+pub const CACHING_REFUSED: &[u8] = b"-ERR CLIENT CACHING";
 
 // larger replies churn the byte budget faster than they earn hits
 const ENTRY_MAX_BYTES: usize = 64 * 1024;

--- a/src/client/broadcast.rs
+++ b/src/client/broadcast.rs
@@ -40,7 +40,7 @@ impl Session {
         frame: Bytes,
         targets: Targets,
         gather: Gather,
-        // a SCRIPT LOAD body with the flush count at its dispatch, remembered under the returned sha
+        // a SCRIPT LOAD frame with the flush count at its dispatch, remembered under the returned sha
         remember: Option<(Bytes, u64)>,
     ) {
         let seq = self.alloc_seq();
@@ -81,10 +81,10 @@ impl Session {
                 Gather::Every => multikey::merge_every(replies.iter()),
                 Gather::PerNode => Ok(per_node(&topo, &nodes, &replies)),
             };
-            if let (Ok(reply), Some((body, flushes))) = (&merged, remember)
+            if let (Ok(reply), Some((load, flushes))) = (&merged, remember)
                 && let Some(sha) = resp::bulk_payload(reply)
             {
-                shared.scripts.remember(sha, body, flushes);
+                shared.scripts.remember(sha, load, flushes);
             }
             link.hold.set(false);
             let _ = reply_q.send(Reply::At(seq, merged.unwrap_or_else(|e| e)));

--- a/src/client/fanout.rs
+++ b/src/client/fanout.rs
@@ -451,6 +451,7 @@ impl Session {
             let _marks = marks;
             let mut results: Vec<(Vec<usize>, Bytes)> = Vec::with_capacity(parts.len());
             let mut retries: Vec<(multikey::Part, oneshot::Receiver<Bytes>)> = Vec::new();
+            let mut reruns: Vec<(multikey::Part, oneshot::Receiver<Bytes>)> = Vec::new();
             let mut singles = Singles::new(merge);
             let mut cached = cached.into_iter();
             for (part, rx) in parts.into_iter().zip(receivers) {
@@ -464,14 +465,9 @@ impl Session {
                     results.push((part.positions, reply));
                     continue;
                 }
-                // a redirected part executed nothing: one resend is idempotent
                 match parse_redirect(&reply) {
                     Some((ask, target)) => {
-                        stats::bump(&shared.wstats.redirects);
-                        let _ = shared.refresh.send(());
-                        let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
-                        let frame = part.frame.clone();
-                        let rx = scatter_one(&shared, target, lane, head, frame).await;
+                        let rx = redirect(&shared, target, ask, lane, &part.frame).await;
                         retries.push((part, rx));
                     }
                     None if reply.starts_with(CACHING_REFUSED) => {
@@ -481,7 +477,7 @@ impl Session {
                                 let addr = &topo.nodes[idx as usize].addr;
                                 let frame = part.frame.clone();
                                 let rx = scatter_one(&shared, addr, lane, None, frame).await;
-                                retries.push((part, rx));
+                                reruns.push((part, rx));
                             }
                             None => results.push((part.positions, reply)),
                         }
@@ -500,6 +496,14 @@ impl Session {
                     }
                     None => results.push((part.positions, reply)),
                 }
+            }
+            for (part, rx) in reruns {
+                let reply = recv_or_lost(rx).await;
+                let rx = match parse_redirect(&reply) {
+                    Some((ask, target)) => redirect(&shared, target, ask, lane, &part.frame).await,
+                    None => resolved(reply),
+                };
+                retries.push((part, rx));
             }
             for (part, rx) in retries {
                 let reply = recv_or_lost(rx).await;
@@ -637,6 +641,20 @@ fn part_head(
         Some(PartCache::Fill(_)) => Some(Some(Bytes::from_static(CACHING_FRAME))),
         _ => Some(None),
     }
+}
+
+// a redirected part executed nothing: one resend is idempotent
+async fn redirect(
+    shared: &Rc<Shared>,
+    target: &str,
+    ask: bool,
+    lane: Lane,
+    frame: &Bytes,
+) -> oneshot::Receiver<Bytes> {
+    stats::bump(&shared.wstats.redirects);
+    let _ = shared.refresh.send(());
+    let head = ask.then(|| Bytes::from_static(ASKING_FRAME));
+    scatter_one(shared, target, lane, head, frame.clone()).await
 }
 
 // a part served from the cache answers through the same channel as a fetched one

--- a/src/client/fanout.rs
+++ b/src/client/fanout.rs
@@ -13,7 +13,7 @@ use super::pipe::{
 use super::session::Session;
 use super::{Cold, ERR_NO_OWNER, Lane, Reply, Shared, error_frame};
 use crate::backend::{ASKING_FRAME, BATCH, ERR_BACKEND_LOST};
-use crate::cache::{CACHING_FRAME, ReplyCache};
+use crate::cache::{CACHING_FRAME, CACHING_REFUSED, ReplyCache};
 use crate::command::{self, Kind, Spec};
 use crate::multikey;
 use crate::resp;
@@ -473,6 +473,17 @@ impl Session {
                         let frame = part.frame.clone();
                         let rx = scatter_one(&shared, target, lane, head, frame).await;
                         retries.push((part, rx));
+                    }
+                    None if reply.starts_with(CACHING_REFUSED) => {
+                        let topo = shared.topo.load_full();
+                        match topo.nodes.get(usize::from(part.node)) {
+                            Some(node) => {
+                                let frame = part.frame.clone();
+                                let rx = scatter_one(&shared, &node.addr, lane, None, frame).await;
+                                retries.push((part, rx));
+                            }
+                            None => results.push((part.positions, reply)),
+                        }
                     }
                     None if degradable && reply.starts_with(b"-TRYAGAIN") => {
                         // boxed: the resend's state must not widen every fan-out's future

--- a/src/client/fanout.rs
+++ b/src/client/fanout.rs
@@ -476,10 +476,11 @@ impl Session {
                     }
                     None if reply.starts_with(CACHING_REFUSED) => {
                         let topo = shared.topo.load_full();
-                        match topo.nodes.get(usize::from(part.node)) {
-                            Some(node) => {
+                        match request_slot(&part.frame).and_then(|s| topo.owner(s)) {
+                            Some(idx) => {
+                                let addr = &topo.nodes[idx as usize].addr;
                                 let frame = part.frame.clone();
-                                let rx = scatter_one(&shared, &node.addr, lane, None, frame).await;
+                                let rx = scatter_one(&shared, addr, lane, None, frame).await;
                                 retries.push((part, rx));
                             }
                             None => results.push((part.positions, reply)),

--- a/src/client/scripting.rs
+++ b/src/client/scripting.rs
@@ -8,6 +8,7 @@ use super::session::Session;
 use crate::command::{self, Spec};
 use crate::crc16;
 use crate::resp;
+use crate::script::Scripts;
 use crate::topology::Topology;
 
 impl Session {
@@ -24,9 +25,8 @@ impl Session {
                     self.emit_error("ERR wrong number of arguments for 'script|load' command");
                     return;
                 };
-                // copied: the request frame is a slice of the session's read buffer
-                let body = Bytes::copy_from_slice(body);
-                let remember = Some((body, self.shared.scripts.flushes()));
+                let load = Scripts::load_of(body);
+                let remember = Some((load, self.shared.scripts.flushes()));
                 (Targets::LiveNodes, Gather::Same, remember)
             }
             "script" if is(b"exists") => (Targets::Masters, Gather::Every, None),

--- a/src/client/session.rs
+++ b/src/client/session.rs
@@ -354,8 +354,8 @@ impl Session {
         let id = if spec.subs.is_empty() {
             spec.id
         } else {
-            resp::Args::new(&frame, argc)
-                .nth(1)
+            it.clone()
+                .next()
                 .and_then(|sub| spec.subcommand(sub))
                 .map_or(spec.id, |sub| sub.id)
         };

--- a/src/client/tuner.rs
+++ b/src/client/tuner.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use super::Shared;
 use super::session::Session;
-use crate::stats::{self, Pipes, Stats};
+use crate::stats::{self, Stats};
 
 // pipelining score: a local session shares at 0, a shared one returns at PIPELINED_LOCAL
 pub(super) const PIPELINED_LOCAL: u8 = 4;
@@ -95,12 +95,6 @@ impl Probe {
             None => self.enter(busy_thin),
         }
         self.prefer
-    }
-
-    fn publish(&self, pipes: &Pipes) {
-        pipes.probes.store(self.probes, Ordering::Relaxed);
-        pipes.keeps.store(self.keeps, Ordering::Relaxed);
-        pipes.reverts.store(self.reverts, Ordering::Relaxed);
     }
 
     // on the shared pipes a rate that fell a quarter under the decided one voids the
@@ -258,7 +252,9 @@ fn conduct(stats: &Stats, probe: &mut Probe) {
     let (busy_thin, still_busy, commands) = survey(stats);
     let prefer = probe.tick(busy_thin, still_busy, commands);
     stats.pipes.prefer.store(prefer, Ordering::Relaxed);
-    probe.publish(&stats.pipes);
+    stats.pipes.probes.store(probe.probes, Ordering::Relaxed);
+    stats.pipes.keeps.store(probe.keeps, Ordering::Relaxed);
+    stats.pipes.reverts.store(probe.reverts, Ordering::Relaxed);
 }
 
 // a worker that has not ticked yet reads as idle and counts against both majorities

--- a/src/client/watch.rs
+++ b/src/client/watch.rs
@@ -147,6 +147,13 @@ impl Watched {
         self.lease.borrow().as_ref().map(|l| l.conn().clone())
     }
 
+    fn conn_dead(&self) -> bool {
+        self.lease
+            .borrow()
+            .as_ref()
+            .is_some_and(|l| l.conn().is_dead())
+    }
+
     fn answer(&self, reply_q: &ReplyQueue, seq: u64, reply: Bytes) {
         self.owed.borrow_mut().retain(|&s| s != seq);
         let _ = reply_q.send(Reply::At(seq, reply));
@@ -461,7 +468,7 @@ impl Session {
                     .push_back(Queued::Cmd { seq, head, frame });
                 None
             }
-            State::Armed | State::Finishing if watched.conn().is_some_and(|c| c.is_dead()) => {
+            State::Armed | State::Finishing if watched.conn_dead() => {
                 watched.die(&self.reply_q, seq, Bytes::from_static(ERR_BACKEND_LOST));
                 None
             }

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -251,23 +251,32 @@ pub(super) async fn write_loop(
                         let _ = shared.refresh.send(());
                         frame = Bytes::from_static(ERR_TRYAGAIN);
                     } else if frame.starts_with(CACHING_REFUSED)
-                        && let Some((retry, slot, db)) = take_bounce(&link, seq)
+                        && let Some((retry, slot, db)) = take_refused(&link, seq)
                     {
                         // the connection re-tracks itself; the request runs again without the opt-in
                         let topo = shared.topo.load_full();
-                        if let Some(idx) = topo.owner(slot) {
-                            let resend = Resend {
-                                shared: &shared,
-                                reply_q: &reply_q,
-                                link: &link,
-                                client_id,
-                            };
-                            resend
-                                .requeue(&topo.nodes[idx as usize].addr, seq, None, retry, 0, db)
-                                .await;
-                            continue;
+                        match topo.owner(slot) {
+                            Some(idx) => {
+                                let resend = Resend {
+                                    shared: &shared,
+                                    reply_q: &reply_q,
+                                    link: &link,
+                                    client_id,
+                                };
+                                let addr = &topo.nodes[idx as usize].addr;
+                                resend.requeue(addr, seq, None, retry, 0, db).await;
+                                continue;
+                            }
+                            None => {
+                                if let Some(fill) = retry.2
+                                    && let Some(cache) = &shared.cache
+                                {
+                                    fill.abandon(cache);
+                                }
+                                let _ = shared.refresh.send(());
+                                frame = Bytes::from_static(ERR_TRYAGAIN);
+                            }
                         }
-                        frame = Bytes::from_static(ERR_TRYAGAIN);
                     } else if frame.starts_with(NOSCRIPT)
                         && rerunnable(&link, seq)
                         && let Some((retry, db, target)) = take_reload(&link, seq)
@@ -504,6 +513,11 @@ fn take_retry(link: &WriterLink, seq: u64, ask: bool, target: &str) -> Option<(R
     let db = entry.db;
     let fill = link.detach_fill(&mut entry);
     Some(((entry.frame.clone(), entry.expect, fill), db))
+}
+
+fn take_refused(link: &WriterLink, seq: u64) -> Option<(Retry, u16, u8)> {
+    let filled = entry_at(&link.inflight, seq)?.fill.is_some();
+    filled.then(|| take_bounce(link, seq)).flatten()
 }
 
 // a request that must wait a topology change out takes one ride, while nothing later holds a sequence

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -18,6 +18,7 @@ use super::queue::ReplyQueue;
 use super::scripting::evalsha_target;
 use super::{ERR_TRYAGAIN, Lane, Reply, Shared};
 use crate::backend::{ASKING_FRAME, BATCH, ERR_BACKEND_LOST, write_frames};
+use crate::cache::CACHING_REFUSED;
 use crate::resp;
 use crate::stats;
 
@@ -248,6 +249,24 @@ pub(super) async fn write_loop(
                         }
                         // clients believe the proxy owns every slot: never leak redirects
                         let _ = shared.refresh.send(());
+                        frame = Bytes::from_static(ERR_TRYAGAIN);
+                    } else if frame.starts_with(CACHING_REFUSED)
+                        && let Some((retry, slot, db)) = take_bounce(&link, seq)
+                    {
+                        // the connection re-tracks itself; the request runs again without the opt-in
+                        let topo = shared.topo.load_full();
+                        if let Some(idx) = topo.owner(slot) {
+                            let resend = Resend {
+                                shared: &shared,
+                                reply_q: &reply_q,
+                                link: &link,
+                                client_id,
+                            };
+                            resend
+                                .requeue(&topo.nodes[idx as usize].addr, seq, None, retry, 0, db)
+                                .await;
+                            continue;
+                        }
                         frame = Bytes::from_static(ERR_TRYAGAIN);
                     } else if frame.starts_with(NOSCRIPT)
                         && rerunnable(&link, seq)

--- a/src/client/writer.rs
+++ b/src/client/writer.rs
@@ -454,6 +454,9 @@ pub(super) async fn write_loop(
             }
             stats::add(&shared.wstats.bytes_out, total as u64);
             ready.clear();
+            if ready.capacity() > 1024 {
+                ready = Vec::with_capacity(BATCH);
+            }
         }
         shared.inflight.set(
             shared

--- a/src/script.rs
+++ b/src/script.rs
@@ -1,4 +1,4 @@
-//! Script bodies loaded through the proxy, replayed to a node that lost them.
+//! SCRIPT LOAD frames carried through the proxy, replayed to a node that lost the script.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
@@ -7,7 +7,7 @@ use bytes::Bytes;
 
 use crate::resp;
 
-/// Process-wide memory of every script SCRIPT LOAD carried.
+/// Process-wide memory of every SCRIPT LOAD frame carried.
 pub struct Scripts {
     inner: Mutex<Inner>,
 }
@@ -17,38 +17,42 @@ impl Scripts {
         Arc::new(Scripts {
             inner: Mutex::new(Inner {
                 flushes: 0,
-                bodies: HashMap::new(),
+                loads: HashMap::new(),
             }),
         })
     }
 
-    /// How many flushes happened so far; a LOAD remembers its body only if none followed it.
+    /// How many flushes happened so far; a LOAD is remembered only if none followed it.
     pub fn flushes(&self) -> u64 {
         self.lock().flushes
     }
 
-    /// Keeps `body` under the sha the nodes returned for it, unless a flush came after the load.
-    pub fn remember(&self, sha: &[u8], body: Bytes, flushes: u64) {
+    /// Keeps `load` under the sha the nodes returned for it, unless a flush came after it.
+    pub fn remember(&self, sha: &[u8], load: Bytes, flushes: u64) {
         let mut inner = self.lock();
         if inner.flushes == flushes {
-            inner.bodies.insert(Box::from(sha), body);
+            inner.loads.insert(Box::from(sha), load);
         }
     }
 
     pub fn forget_all(&self) {
         let mut inner = self.lock();
         inner.flushes += 1;
-        inner.bodies = HashMap::new();
+        inner.loads = HashMap::new();
     }
 
-    /// A SCRIPT LOAD frame for the script an EVALSHA request names, when the proxy loaded it.
+    /// The SCRIPT LOAD frame for the script an EVALSHA request names, when the proxy carried it.
     pub fn load_frame(&self, evalsha: &[u8]) -> Option<Bytes> {
         let (argc, _) = resp::scan_int_line(evalsha, 1)?;
         let sha = resp::Args::new(evalsha, argc as usize).nth(1)?;
-        let body = self.lock().bodies.get(sha)?.clone();
+        self.lock().loads.get(sha).cloned()
+    }
+
+    /// The frame a SCRIPT LOAD of `body` sends, copied out of the request it came in.
+    pub fn load_of(body: &[u8]) -> Bytes {
         let mut out = Vec::with_capacity(body.len() + 32);
-        resp::write_command(&mut out, &[b"SCRIPT", b"LOAD", &body]);
-        Some(Bytes::from(out))
+        resp::write_command(&mut out, &[b"SCRIPT", b"LOAD", body]);
+        Bytes::from(out)
     }
 
     fn lock(&self) -> MutexGuard<'_, Inner> {
@@ -58,7 +62,7 @@ impl Scripts {
 
 struct Inner {
     flushes: u64,
-    bodies: HashMap<Box<[u8]>, Bytes>,
+    loads: HashMap<Box<[u8]>, Bytes>,
 }
 
 #[cfg(test)]
@@ -71,24 +75,16 @@ mod tests {
         let mut req = Vec::new();
         resp::write_command(&mut req, &[b"EVALSHA", b"abc123", b"1", b"k"]);
         assert!(scripts.load_frame(&req).is_none());
-        scripts.remember(
-            b"abc123",
-            Bytes::from_static(b"return 1"),
-            scripts.flushes(),
-        );
+        scripts.remember(b"abc123", Scripts::load_of(b"return 1"), scripts.flushes());
         let mut want = Vec::new();
         resp::write_command(&mut want, &[b"SCRIPT", b"LOAD", b"return 1"]);
         assert_eq!(scripts.load_frame(&req).as_deref(), Some(want.as_slice()));
         let before = scripts.flushes();
         scripts.forget_all();
         assert!(scripts.load_frame(&req).is_none());
-        scripts.remember(b"abc123", Bytes::from_static(b"return 1"), before);
+        scripts.remember(b"abc123", Scripts::load_of(b"return 1"), before);
         assert!(scripts.load_frame(&req).is_none());
-        scripts.remember(
-            b"abc123",
-            Bytes::from_static(b"return 1"),
-            scripts.flushes(),
-        );
+        scripts.remember(b"abc123", Scripts::load_of(b"return 1"), scripts.flushes());
         assert!(scripts.load_frame(&req).is_some());
     }
 }

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -159,10 +159,7 @@ pub async fn control_loop(
         tokio::select! {
             nc = ctl.recv() => {
                 let Some(mut nc) = nc else { return };
-                let frame = match &tracking {
-                    Some(t) if !nc.readonly && nc.db == 0 => t.borrow().get(nc.addr.as_str()).cloned(),
-                    _ => None,
-                };
+                let tracking = tracking.clone();
                 let fabric = fabric.clone();
                 let cfg = cfg.clone();
                 tokio::task::spawn_local(async move {
@@ -170,7 +167,7 @@ pub async fn control_loop(
                         (&nc.addr, nc.db),
                         nc.readonly,
                         &cfg,
-                        frame.as_deref(),
+                        tracking.as_ref(),
                         &mut nc.rx,
                         (None, None),
                         deliver,


### PR DESCRIPTION
Three things: the last open row of the loc-justify cut-list, the reply cache's refused-opt-in intermittent, and an ownership walkthrough of the whole crate.

- `Probe::publish` is inlined into `conduct`, which already stores the preference (−3 lines).
- Dials, rearms and tracker arrivals log at debug level, so a tracking anomaly can be read back from a proxy log.
- A backend that answers a fill's `CLIENT CACHING YES` with the tracking-off error is now harmless: the pairing loop reports the refusal, the connection sends its current tracking frame again on its own account (logged at warn once the frame is written), and the request runs again without the opt-in, abandoning its fill, so the client sees its reply and nothing fills. A fan-out part reruns at its slot's current owner; a single request reruns while it is the session's last in flight, since a rerun behind later commands would reorder them. Only a request that held a fill reruns, so an application error of the same text never runs a command twice. Connections resolve the tracking frame from the shared map at handshake instead of carrying one captured at dial time.
- The ownership walkthrough (every source file read in full for clones, copies and borrow shapes) applied its per-command rows: a remembered script is stored as its `SCRIPT LOAD` frame, so a watched EVALSHA takes a refcount instead of copying the body; the dispatch subcommand lookup clones the positioned argument iterator instead of re-scanning the frame; a watched command checks its connection through the lease borrow instead of cloning the `Rc`; the writer's ready buffer gets the capacity valve its siblings have; `IOV_STACK` grows to 64 so a pipelined batch keeps its iovec on the stack.

The refusal was seen twice in about forty compatibility-matrix runs of the redis 8.2 / reply-cache cell and never in about 120 isolated runs of the same cell; every fill path reads as covered by the dial-time frame or the tracker's rearm, so this closes the effect rather than a window that could be named. Nothing new runs on the reply path outside the existing error branches.

Measured on a 128-master rig, 64 workers, three arms rotated over nine rounds, P16 1000 conns: the fix against master GET 8.65M → 8.72M (+0.9%, A/A +0.05%), SET 9.01M → 9.04M (+0.4%, A/A −0.2%); the final head GET 8.67M → 8.77M (+1.3%, median +0.0%, A/A +0.9%), SET 9.10M → 9.08M (−0.2%, A/A −0.6%). Flat inside the A/A floor both times.

Gates: unit 118; the 15-cell compatibility matrix green; ct1 IT ×8 green, functional suite 165 / 163 passed. Review converged.
